### PR TITLE
Fix/tile brand non media

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Toolkit UI v0.3.2
+
+## 1. Bug Fixes
+- [tile] Changed tile brand modifiers class to `.c-tile__body` rather than `.c-tile__caption` so that it applies to all tiles rather than just the split media tiles
+
+===
+
 # Toolkit UI v0.3.1
 
 ## 1. Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1. Bug Fixes
 - [tile] Changed tile brand modifiers class to `.c-tile__body` rather than `.c-tile__caption` so that it applies to all tiles rather than just the split media tiles
+- [select] Fixes gap in bg and border on hover state caused by duplicate `border-radius` properties.
 
 ===
 

--- a/components/_select.scss
+++ b/components/_select.scss
@@ -62,7 +62,6 @@ $select-animation-speed: $global-animation-speed-fast !default;
     background-position: center; /* [6] */
     background-size: contain; /* [6] */
     border: solid $select-icon-padding transparent; /* [7] */
-    border-radius: 0 $select-border-radius $select-border-radius 0; /* [8] */
     transition: transform $select-animation-speed ease, background-color $select-animation-speed ease; /* [9] */
     -ms-transform: translate($select-icon-width, 0); /* [9] */
     transform: translate($select-icon-width, 0); /* [9] */

--- a/components/_tile.scss
+++ b/components/_tile.scss
@@ -370,7 +370,7 @@ $included-tile-themes: "sky-1", "sky-account", "sky-atlantic", "sky-arts", "sky-
       }
 
       // Set up style overides
-      .c-tile__link .c-tile__caption::after {
+      .c-tile__link .c-tile__body::after {
         @include background-gradient($brand);
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sky-toolkit-ui",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "The UI layer of Sky's web toolkit",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
# Toolkit UI v0.3.2

## 1. Bug Fixes
- [tile] Changed tile brand modifiers class to `.c-tile__body` rather than `.c-tile__caption` so that it applies to all tiles rather than just the split media tiles