### PR TITLE
Make transition on c-spinner more specific

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Toolkit UI v0.3.7
+
+## 1. Bug Fixes
+- [spinner] Changed the `.c-spinner` transition from targeting all properties to target opacity and visibility as these are the properties that need to be transitioned when the `.is-complete` class is added.
+
+===
+
 # Toolkit UI v0.3.6
 
 ## 1. Bug Fixes

--- a/components/_spinner.scss
+++ b/components/_spinner.scss
@@ -31,7 +31,7 @@ $spinner-transition-delay: $global-animation-speed;
   animation: spin $spinner-animation-speed infinite linear;
   opacity: 1;
   visibility: visible;
-  transition: all $spinner-animation-speed ease;
+  transition: opacity $spinner-animation-speed ease, visibility $spinner-animation-speed ease;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sky-toolkit-ui",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "The UI layer of Sky's web toolkit",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The transition on the `.c-spinner` element targeted all properties. The accessibility 'loading' text has a text-indent of 100% which was being transitioned from 0% to 100% over a second. This meant that the loading text was visible until it had indented outside of the `.c-spinner-overlay` container.

I changed the `.c-spinner` transition to target opacity and visibility as these are the properties that need to be transitioned when the `.is-complete` class is added.