### PR TITLE
Idea to show how we could treat opt in styles

### DIFF
--- a/components/_select.scss
+++ b/components/_select.scss
@@ -73,18 +73,29 @@ $select-animation-speed: $global-animation-speed-fast !default;
   &:focus {
     border-color: color(highlight); /* [10] */
   }
+}
 
-  &:hover,
-  &:active {
-    padding-left: $global-spacing-unit;  /* [11] */
-    padding-right: $global-spacing-unit+$select-icon-width;  /* [11] */
+/**
+ * Mixin to provide a hover style that can be opted into with feature detection or condtional classes - see sample below
+ **/
+@mixin c-select__btn--hover {
+  .c-select__btn {
+    &:hover,
+    &:active {
+      padding-left: $global-spacing-unit;  /* [11] */
+      padding-right: $global-spacing-unit+$select-icon-width;  /* [11] */
 
-    &::after {
-      -ms-transform: translate(0, 0);  /* [12] */
-      transform: translate(0, 0);  /* [12] */
+      &::after {
+        -ms-transform: translate(0, 0);  /* [12] */
+        transform: translate(0, 0);  /* [12] */
+      }
     }
   }
+}
 
+/* Sample feature detection class allowing opt in to hover styling */
+.no-touch {
+  @include c-select__btn--hover;
 }
 
 /**


### PR DESCRIPTION
I'm taking a stab at solving [issue 118](https://github.com/sky-uk/toolkit-ui/issues/118). 
Using mixins in this way might be controversial and means we loose the hover effect out of the box with straight CSS - hope it will prompt discussion.
