### PR TITLE
Fix for select button rendering issue in Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
-# Toolkit UI v0.3.10
+# Toolkit UI v0.4.0
 
-## 1. Enhancement
-- [Tooltip] Added `c-tooltip--hover` modifier to allow tooltips to be triggered on hover.
+## 1. Enhancements
+- [buttons] Secondary (invert) hover color changed to align with branding.
+- [panels] Panels now utilise a white background by default.
+- [tiles] Sky Cinema gradient implemented to `c-tile`, replacing Sky Movies.
+- [typography] New responsive Typographic scale (and added to components where used).
+
+## 2. Deprecations
+- [legacy-typography] We removed the previous typographic variables in favour of a responsive approach. To deprecate gracefully, a toggle variable has been provided in settings/config.
+- [panels] Following branding, grey panels are no longer used.
 
 ===
 

--- a/components/_accordion.scss
+++ b/components/_accordion.scss
@@ -49,7 +49,7 @@ $accordion-icon-size: 20px !default;
  * 5. Overwrite browser interaction styles to hide outline and show pointer.
  */
 .c-accordion__label {
-  @include font-size($text-body-small); /* [1] */
+  @include font-size(text-body-small); /* [1] */
   display: block; /* [2] */
   position: relative; /* [2] */
   font-weight: bold; /* [1] */

--- a/components/_buttons.scss
+++ b/components/_buttons.scss
@@ -161,7 +161,7 @@ $btn-animation-speed-fast: $global-animation-speed-fast !default;
   padding-right: $global-spacing-unit-large;
   color: color(brand);
   background-color: transparent;
-  border-color: color(brand);
+  border: none;
   transition: all $btn-animation-speed-fast ease;
 }
 

--- a/components/_buttons.scss
+++ b/components/_buttons.scss
@@ -3,9 +3,9 @@
    ========================================================================== */
 
 // Button settings
-$btn-font-size: 18px !default;
-$btn-padding-x: $global-spacing-unit-small !default;
-$btn-padding-y: $global-spacing-unit-tiny !default;
+$btn-font-size: text(text-lead-small) !default;
+$btn-padding-x: 15px !default;
+$btn-padding-y: 5px !default;
 $btn-border-width: $global-border-width !default;
 $btn-border-radius: $global-border-radius !default;
 $btn-animation-speed: $global-animation-speed !default;
@@ -109,8 +109,9 @@ $btn-animation-speed-fast: $global-animation-speed-fast !default;
   &:hover,
   &:active,
   &:focus {
-    background-color: color(highlight);
-    border-color: color(highlight);
+    color: color(text);
+    background-color: color(white);
+    border-color: color(white);
   }
 }
 
@@ -155,10 +156,12 @@ $btn-animation-speed-fast: $global-animation-speed-fast !default;
 * e.g. `<span class="c-btn  c-btn--select  c-select__btn">Select</span>`
 *
 * A. https://en.bem.info/forum/4/
+*
+* 1. This should be the same value as the icon width used in _select.scss
 */
 .c-btn--select {
-  padding-left: $global-spacing-unit-large;
-  padding-right: $global-spacing-unit-large;
+  padding-left: 40px;/* [1] */
+  padding-right: 40px;/* [1] */
   color: color(brand);
   background-color: transparent;
   border: none;

--- a/components/_dropdown.scss
+++ b/components/_dropdown.scss
@@ -8,7 +8,6 @@ $dropdown-background: color(white) !default;
 $dropdown-background-focus: #f4f4f4 !default;
 $dropdown-border: 1px solid color(keyline) !default;
 $dropdown-border-radius: $global-border-radius !default;
-$dropdown-font-size: $text-body-small !default;
 $dropdown-shadow-blur-radius: 8px !default;
 $dropdown-shadow: 0 0 0 0 rgba(0, 0, 0, 0.2) !default;
 $dropdown-shadow-focus: 0 0 $dropdown-shadow-blur-radius 0 rgba(0, 0, 0, 0.2) !default;
@@ -45,7 +44,7 @@ $dropdown-shadow-focus: 0 0 $dropdown-shadow-blur-radius 0 rgba(0, 0, 0, 0.2) !d
  * 12. Sets animation settings on transition.
  */
 .c-dropdown__label {
-  @include font-size($dropdown-font-size); /* [1] */
+  @include font-size(text-lead-small); /* [1] */
   display: block; /* [2] */
   position: relative; /* [3] */
   font-weight: bold; /* [4] */
@@ -166,7 +165,7 @@ $dropdown-shadow-focus: 0 0 $dropdown-shadow-blur-radius 0 rgba(0, 0, 0, 0.2) !d
  * 9. As we can't hide the overflow, a border-radius is set on the last-child.
  */
 .c-dropdown__link {
-  @include font-size($dropdown-font-size); /* [1] */
+  @include font-size(text-lead-small); /* [1] */
   display: block; /* [2] */
   width: 100%; /* [2] */
   padding: $global-spacing-unit-tiny/2 $global-spacing-unit-small; /* [3] */

--- a/components/_forms.scss
+++ b/components/_forms.scss
@@ -8,7 +8,7 @@ $form-shadow-focus: 0 0 8px 0 rgba(0, 0, 0, 0.2);
 $form-shadow-error: 0 0 8px 0 rgba(color(error), 0.75);
 $form-background: color(white);
 $form-border: 1px solid color(keyline);
-$form-font-size: $text-body-small;
+$form-font-size: text-lead-small;
 $form-animation-speed: $global-animation-speed-fast;
 
 /* Form list
@@ -82,7 +82,7 @@ $form-animation-speed: $global-animation-speed-fast;
  *
  */
 .c-form-label {
-  @include font-size($form-font-size);
+  @include font-size($form-font-size, large);
   display: inline-block;
   margin-bottom: $global-spacing-unit-tiny;
 }
@@ -94,21 +94,21 @@ $form-animation-speed: $global-animation-speed-fast;
  * All text-like form inputs require a class of `.c-form-input`: we do not use
  * selectors like `input[type="text"] {}`.
  *
- * 1. Fix for IE 10/11 removing input vertical padding from inputs.
- * 2. Spacing is readded using line-height/height as an alternative (39px).
+ * 1. Fix for IE 10/11 removing vertical padding from inputs which was being ignored.
+ * 2. Padding added via line-height/height to re-center text for all browsers (38px to account for border).
  */
 .c-form-input {
-  @include font-size($form-font-size);
+  @include font-size($form-font-size, large);
   display: inline-block;
   padding: 0 $global-spacing-unit-tiny; /* [1] */
   margin-bottom: $global-spacing-unit-tiny;
-  height: 2.167em; /* [2] */
+  height: 2.111em; /* [2] */
   width: 100%;
   background-color: $form-background;
   border: $form-border;
   border-radius: $global-border-radius;
   box-shadow: $form-shadow;
-  line-height: 2.167em; /* [2] */
+  line-height: 2.111em; /* [2] */
   transition: box-shadow $form-animation-speed ease, border-color $form-animation-speed ease;
   outline: 0;
   -webkit-appearance: none;
@@ -138,7 +138,7 @@ $form-animation-speed: $global-animation-speed-fast;
  * iOS Safari and Android. Other browsers will fallback to a text field.
  */
 .c-form-date {
-  @include font-size($form-font-size);
+  @include font-size($form-font-size, large);
   display: inline-block;
   padding: $global-spacing-unit-tiny/2 $global-spacing-unit-tiny;
   margin-bottom: $global-spacing-unit-tiny;
@@ -186,6 +186,7 @@ $form-animation-speed: $global-animation-speed-fast;
 .c-form-combo__cell {
   display: table-cell;
   width: 100%;
+  vertical-align: top;
 }
 
 /**
@@ -197,9 +198,14 @@ $form-animation-speed: $global-animation-speed-fast;
   border-right: 0;
 }
 
+/*
+ * 1. Brings combo button height in line with input height (38px to account for 2px border).
+ */
+
 .c-form-combo__btn {
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
+  height: 2.111em; /* [1] */
   white-space: nowrap;
 }
 
@@ -209,7 +215,7 @@ $form-animation-speed: $global-animation-speed-fast;
  */
 .c-form-combo__btn,
 .c-form-combo__input {
-  @include font-size($form-font-size);
+  @include font-size($form-font-size, large);
   padding-top: $global-spacing-unit-tiny/2;
   padding-bottom: $global-spacing-unit-tiny/2;
 }
@@ -218,7 +224,7 @@ $form-animation-speed: $global-animation-speed-fast;
   =========================================== */
 
 .c-form-select {
-  @include font-size($form-font-size);
+  @include font-size($form-font-size, large);
   display: inline-block;
   margin-bottom: $global-spacing-unit-tiny;
   position: relative;
@@ -244,7 +250,7 @@ $form-animation-speed: $global-animation-speed-fast;
 }
 
 .c-form-select__dropdown {
-  @include font-size($form-font-size);
+  @include font-size($form-font-size, large);
   padding: $global-spacing-unit-tiny/2 $global-spacing-unit-tiny;
   width: 100%;
   border: $form-border;
@@ -273,7 +279,7 @@ $form-animation-speed: $global-animation-speed-fast;
   display: inline-block;
   width: 100%;
   margin-bottom: $global-spacing-unit-tiny;
-  font-size: $form-font-size;
+  font-size: text($form-font-size);
   cursor: pointer;
 }
 
@@ -285,9 +291,9 @@ $form-animation-speed: $global-animation-speed-fast;
   display: inline-block;
   margin-right: $global-spacing-unit-tiny;
   position: relative;
-  width: $form-font-size;
+  width: text($form-font-size);
   top: 3px;
-  height: $form-font-size;
+  height: text($form-font-size);
   background-color: $form-background;
   border: $form-border;
 }

--- a/components/_panel.scss
+++ b/components/_panel.scss
@@ -3,8 +3,12 @@
    ========================================================================== */
 
 // Panel settings
-$panel-gradient: linear-gradient(to bottom, rgba(160, 160, 160, 0.5) 0%, rgba(0, 0, 0, 0) 12px), linear-gradient(to top, rgba(160, 160, 160, 0.5) 0%, rgba(0, 0, 0, 0) 12px);
-$panel-background-color: color(ui-light) !default;
+$panel-shadow-size: inset 0 0 12px 0;
+$panel-shadow-color: #9f9f9f;
+$panel-shadow-color-dark: color(black);
+$panel-shadow: $panel-shadow-size $panel-shadow-color;
+$panel-shadow-dark: $panel-shadow-size $panel-shadow-color-dark;
+$panel-background-color: color(white) !default;
 $panel-background-color-dark: color(ui-dark) !default;
 
 /**
@@ -17,7 +21,7 @@ $panel-background-color-dark: color(ui-dark) !default;
   width: 100vw; /* [1] */
   margin-left: -50vw; /* [1] */
   background: $panel-background-color;
-  background-image: $panel-gradient;
+  box-shadow: $panel-shadow;
   transition: $global-animation-speed linear;
   transition-property: max-height, margin-bottom;
   overflow: hidden;
@@ -43,7 +47,7 @@ $panel-background-color-dark: color(ui-dark) !default;
 
 .c-panel--dark {
   background-color: $panel-background-color-dark;
-  background-image: none; /* [1] */
+  box-shadow: $panel-shadow-dark;
   color: color(white);
 }
 
@@ -57,8 +61,8 @@ $panel-background-color-dark: color(ui-dark) !default;
   */
 
 .c-panel__toggle {
-  @include font-size($text-body-small, 1);
-
+  @include font-size(text-lead-small);
+  line-height: 1;
   position: absolute; /* [1] */
   top: $global-spacing-unit-small; /* [1] */
   right: $global-spacing-unit-small; /* [1] */

--- a/components/_select.scss
+++ b/components/_select.scss
@@ -25,6 +25,7 @@ $select-animation-speed: $global-animation-speed-fast !default;
   overflow: hidden; /* [4] */
   border-radius: $select-border-radius; /* [5] */
   perspective: 1px; /* [6] */
+  border: 1px solid color(brand);
 }
 
 /**

--- a/components/_select.scss
+++ b/components/_select.scss
@@ -3,10 +3,13 @@
    ========================================================================== */
 
 // Select settings
+/*
+* 1. Should be kept consitant with padding used on .c-btn--select
+*/
 $select-border-width: $global-border-width !default;
 $select-border-radius: $global-border-radius !default;
 $select-icon-padding: $global-spacing-unit-tiny !default;
-$select-icon-width: $global-spacing-unit-large !default;
+$select-icon-width: 40px !default; /* [1] */
 $select-animation-speed: $global-animation-speed-fast !default;
 
 /**
@@ -77,8 +80,8 @@ $select-animation-speed: $global-animation-speed-fast !default;
 
   &:hover,
   &:active {
-    padding-left: $global-spacing-unit;  /* [11] */
-    padding-right: $global-spacing-unit+$select-icon-width;  /* [11] */
+    padding-left: $select-icon-width / 2;  /* [11] */
+    padding-right: $select-icon-width / 2 + $select-icon-width;  /* [11] */
 
     &::after {
       -ms-transform: translate(0, 0);  /* [12] */
@@ -98,8 +101,8 @@ $select-animation-speed: $global-animation-speed-fast !default;
   display: none;  /* [1] */
 
   &:checked + .c-select__btn {
-    padding-left: $global-spacing-unit;  /* [2] */
-    padding-right: $global-spacing-unit+$select-icon-width;  /* [2] */
+    padding-left: $select-icon-width / 2;  /* [2] */
+    padding-right: $select-icon-width / 2 + $select-icon-width;  /* [2] */
 
     &::after {
       -ms-transform: translate(0, 0);  /* [3] */

--- a/components/_tile.scss
+++ b/components/_tile.scss
@@ -10,7 +10,7 @@ $tile-animation-speed: $global-animation-speed;
 $tile-animation-speed-slow: $global-animation-speed-slow;
 $tile-shadow: $global-shadow !default;
 $tile-arrow-size: 22px !default;
-$tile-arrow-color: #e6e6ea;
+$tile-arrow-color: color(white);
 $tile-shadow-color: rgba(160, 160, 160, 0.5);
 $tile-gradient-default: "small";
 $tile-gradient-default-hover: "large";
@@ -28,7 +28,7 @@ $tile-gradient-default-hover: "large";
  *
  */
 
-$included-tile-themes: "sky-1", "sky-account", "sky-atlantic", "sky-arts", "sky-box-sets", "sky-kids", "sky-living", "sky-movies", "sky-news", "sky-sports", "sky-store" !default;
+$included-tile-themes: "sky-1", "sky-account", "sky-atlantic", "sky-arts", "sky-box-sets", "sky-cinema", "sky-kids", "sky-living", "sky-news", "sky-sports", "sky-store" !default;
 
 /**
  * The base of the tile; provides the glass "border" and shadow.
@@ -55,10 +55,13 @@ $included-tile-themes: "sky-1", "sky-account", "sky-atlantic", "sky-arts", "sky-
      * 2. Need to take off an extra pixel here to allow for browser rendering/
      *    rounding quirks.
      * 3. Rotate 45deg to allow it to mask the panel gradient and look like a
-     *    notch in the panel
-     * 4. Gradients along the top and left to simulate shadow
+     *    notch in the panel (webkit placed after to prevent render quirk)
+     * 4. Box-shadow that matches the panel background color to smooth the
+     *    shadow transition
+     * 5. Inset box-shadow that is offset to be visible only on the top edges
      */
-    &::before {
+    &::before,
+    &::after {
       display: block;
       content: "";
       position: absolute;  /* [1] */
@@ -67,16 +70,30 @@ $included-tile-themes: "sky-1", "sky-account", "sky-atlantic", "sky-arts", "sky-
       width: $tile-arrow-size;
       height: $tile-arrow-size;
       margin-left: -$tile-arrow-size/2; /* [1] */
-      -ms-transform: rotate(45deg);
-      transform: rotate(45deg);
+      -ms-transform: rotate(45deg); /* [3] */
+      transform: rotate(45deg); /* [3] */
+      -webkit-transform: translate3d(0, 0, 0) rotate(45deg); /* [3] */
+    }
+
+    &::before {
+      box-shadow: 5px 5px 8px $tile-arrow-color; /* [4] */
+    }
+
+    &::after {
       background-color: $tile-arrow-color;
-      background-image: linear-gradient(to bottom, $tile-shadow-color 0%, rgba(0, 0, 0, 0) 15px), linear-gradient(to right, $tile-shadow-color 0%, rgba(0, 0, 0, 0) 15px) /* [4] */
+      box-shadow: inset $tile-arrow-size/2 $tile-arrow-size/2 $tile-arrow-size/2 (-$tile-arrow-size / 2) #9f9f9f; /* [5] */
     }
   }
 
-  &.c-tile--dark.is-selected::before {
-    background-color: color(ui-dark);
-    background-image: none;
+  &.c-tile--dark.is-selected {
+    &::before {
+      box-shadow: 5px 5px 8px color(ui-dark); /* [4] */
+    }
+
+    &::after {
+      background-color: color(ui-dark);
+      box-shadow: inset $tile-arrow-size/2 $tile-arrow-size/2 $tile-arrow-size/2 (-$tile-arrow-size / 2) color(black); /* [5] */
+    }
   }
 }
 
@@ -217,7 +234,7 @@ $included-tile-themes: "sky-1", "sky-account", "sky-atlantic", "sky-arts", "sky-
  */
 .c-tile__title {
   position: relative;
-  font-size: $text-delta;
+  font-size: text(heading-delta);
   line-height: 1.3;
 
   @include mq($from: medium) {
@@ -225,7 +242,7 @@ $included-tile-themes: "sky-1", "sky-account", "sky-atlantic", "sky-arts", "sky-
   }
 
   @include mq($from: large) {
-    font-size: $text-gamma;
+    font-size: text(heading-charlie);
   }
 }
 
@@ -234,11 +251,11 @@ $included-tile-themes: "sky-1", "sky-account", "sky-atlantic", "sky-arts", "sky-
  */
 .c-tile__small-title {
   position: relative;
-  font-size: $text-delta;
+  font-size: text(heading-delta);
   line-height: 1.3;
 
   @include mq($from: medium) {
-    font-size: $text-body;
+    font-size: text(text-lead);
   }
 }
 

--- a/components/_tooltip.scss
+++ b/components/_tooltip.scss
@@ -89,7 +89,7 @@ $tooltip-z-base: 50;
 
   .is-active &,
   .c-tooltip--hover:hover & {
-    @include font-size($text-body-small);
+    @include font-size(text-body-small);
     display: block;
     position: absolute;
     z-index: $tooltip-z-base+2; /* [1] */

--- a/components/_typography.scss
+++ b/components/_typography.scss
@@ -10,36 +10,145 @@
  * Further reading: http://csswizardry.com/2016/02/managing-typography-on-large-apps/
  */
 
-/* Heading-level typography
+@if $legacy-typography == false {
+  /* Heading-level typography
+    =========================================== */
+
+  .c-heading-alpha {
+    @include font-size(heading-alpha, small);
+    line-height: 1.3;
+
+    @include mq($from: medium) {
+      @include font-size(heading-alpha, large);
+      line-height: 1.2;
+    }
+  }
+
+  .c-heading-bravo {
+    @include font-size(heading-bravo, small);
+    line-height: 1.3;
+
+    @include mq($from: medium) {
+      @include font-size(heading-bravo, large);
+      line-height: 1.25;
+    }
+  }
+
+  .c-heading-charlie {
+    @include font-size(heading-charlie, small);
+    line-height: 1.3;
+
+    @include mq($from: medium) {
+      @include font-size(heading-charlie, large);
+      line-height: 1.25;
+    }
+  }
+
+  .c-heading-delta {
+    @include font-size(heading-delta, small);
+    line-height: 1.4;
+
+    @include mq($from: medium) {
+      @include font-size(heading-delta, large);
+      line-height: 1.3;
+    }
+  }
+
+  /* Text-level typography
+    =========================================== */
+
+  .c-text-lead {
+    @include font-size(text-lead, small);
+    line-height: 1.4;
+
+    @include mq($from: medium) {
+      @include font-size(text-lead, large);
+      line-height: 1.4;
+    }
+  }
+
+  .c-text-body {
+    @include font-size(text-body, small);
+    line-height: 1.4;
+
+    @include mq($from: medium) {
+      @include font-size(text-body, large);
+      line-height: 1.4;
+    }
+  }
+
+  .c-text-lead-small {
+    @include font-size(text-lead-small, small);
+    line-height: 1.5;
+
+    @include mq($from: medium) {
+      @include font-size(text-lead-small, large);
+      line-height: 1.4;
+    }
+  }
+
+  .c-text-body-small {
+    @include font-size(text-body-small, small);
+    line-height: 1.5;
+
+    @include mq($from: medium) {
+      @include font-size(text-body-small, large);
+      line-height: 1.5;
+    }
+  }
+
+  .c-text-smallprint {
+    @include font-size(text-smallprint, small);
+    line-height: 1.4;
+
+    @include mq($from: medium) {
+      @include font-size(text-smallprint, large);
+      line-height: 1.4;
+    }
+  }
+}
+
+@else {
+  @warn "Legacy typography will be deprecated in the near future. Please amend your typographic classes. For more info, visit sky.com/blackjack/toolkit/style/typography ";
+
+  /* Heading-level typography
   =========================================== */
 
-.c-heading-alpha {
-  @include font-size($text-alpha);
-}
+  .c-heading-alpha {
+    @include font-size(heading-alpha, large);
+    line-height: 1.2;
+  }
 
-.c-heading-beta {
-  @include font-size($text-beta);
-}
+  .c-heading-beta {
+    @include font-size(heading-bravo, large);
+    line-height: 1.25;
+  }
 
-.c-heading-gamma {
-  @include font-size($text-gamma, 1.3);
-}
+  .c-heading-gamma {
+    @include font-size(heading-charlie, large);
+    line-height: 1.25;
+  }
 
-.c-heading-delta {
-  @include font-size($text-delta);
-}
+  .c-heading-delta {
+    @include font-size(heading-delta, large);
+    line-height: 1.3;
+  }
 
-/* Text-level typography
-  =========================================== */
+  /* Text-level typography
+    =========================================== */
 
-.c-text-body {
-  @include font-size($text-body);
-}
+  .c-text-body {
+    @include font-size(text-lead, large);
+    line-height: 1.4;
+  }
 
-.c-text-body-small {
-  @include font-size($text-body-small);
-}
+  .c-text-body-small {
+    @include font-size(text-body-small, large);
+    line-height: 1.5;
+  }
 
-.c-text-caption {
-  @include font-size($text-caption, 1.3);
+  .c-text-caption {
+    @include font-size(text-smallprint, large);
+    line-height: 1.4;
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sky-toolkit-ui",
-  "version": "0.3.10",
+  "version": "0.4.0",
   "description": "The UI layer of Sky's web toolkit",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
If you have multiple select buttons, at certain browser widths the right hand side of a select button can be obscured (see screen shots below).

This fix moves the border style from the button to the containing label

![screen shot 2016-08-12 at 14 25 05](https://cloud.githubusercontent.com/assets/1849493/17624025/d3e1a26a-609a-11e6-8327-24ce0472577a.png)
![screen shot 2016-08-12 at 14 16 48](https://cloud.githubusercontent.com/assets/1849493/17624026/d3e7314e-609a-11e6-868b-6c6e3ea4bf31.png)

