### PR TITLE
Reduced nesting of hoverstates and fixed c-tile__link when square

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Toolkit UI v0.4.2
+
+## 1. Bug Fixes
+- [tiles] Only title now underlines on hover.
+- [tiles] Specificity reduced with hover style allowing easier customisation
+
+===
+
 # Toolkit UI v0.4.1
 
 ## 1. Enhancements

--- a/components/_tile.scss
+++ b/components/_tile.scss
@@ -139,10 +139,17 @@ $included-tile-themes: "sky-1", "sky-account", "sky-atlantic", "sky-arts", "sky-
   color: inherit;
   transition: color $tile-animation-speed ease;
 
-  &,
-  &:hover,
-  &:focus {
-    text-decoration: none;
+  .c-tile--square & {
+    bottom: 0;
+    left: 0;
+    position: absolute;
+    right: 0;
+    top: 0;
+  }
+
+  &:focus .c-tile__title,
+  &:hover .c-tile__title {
+    text-decoration: underline;
   }
 }
 
@@ -306,8 +313,8 @@ $included-tile-themes: "sky-1", "sky-account", "sky-atlantic", "sky-arts", "sky-
     z-index: -1; // Set between before and content.
   }
 
-  .c-tile__content:hover &::after,
-  .c-tile__content:focus &::after {
+  .c-tile__link:hover &::after,
+  .c-tile__link:focus &::after {
     opacity: 1; // Set hover opacity
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sky-toolkit-ui",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "The UI layer of Sky's web toolkit",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
We have had a few issues with overriding the default hover states for the tiles, currently all content is set to underline which isn't actually correct. Only the title should show underline on hover.

The hover logic has been simplified so specificity is lower too making custom changes easier. One of the main reasons for this is that when using `.c-tile__square`, the `.c-tile__link` losses height and caused some issues, rather than hacking around it this should fix the route of the issue.