### PR TITLE
Fix for broken select button display in iOS8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# Toolkit UI v0.4.1
+
+## 1. Enhancements
+- [select] Reduced horizontal padding from 60px to 40px.
+
+## 1. Bug Fixes
+- [select] Border styles are now applied to the label element, this resolves a rendering issue were multiple select buttons  lost their borders.
+- [select] Webkit vendor prefixes applied so buttons look and function correctly in older versions of Safari (including iOS8).
+
+===
+
 # Toolkit UI v0.4.0
 
 ## 1. Enhancements

--- a/components/_select.scss
+++ b/components/_select.scss
@@ -66,8 +66,9 @@ $select-animation-speed: $global-animation-speed-fast !default;
     background-size: contain; /* [6] */
     border: solid $select-icon-padding transparent; /* [7] */
     transition: transform $select-animation-speed ease, background-color $select-animation-speed ease; /* [9] */
-    -ms-transform: translate($select-icon-width, 0); /* [9] */
-    transform: translate($select-icon-width, 0); /* [9] */
+        -ms-transform: translate($select-icon-width, 0); /* [9] */
+    -webkit-transform: translate($select-icon-width, 0); /* [9] */
+            transform: translate($select-icon-width, 0); /* [9] */
   }
 
   &:focus {
@@ -80,8 +81,9 @@ $select-animation-speed: $global-animation-speed-fast !default;
     padding-right: $global-spacing-unit+$select-icon-width;  /* [11] */
 
     &::after {
-      -ms-transform: translate(0, 0);  /* [12] */
-      transform: translate(0, 0);  /* [12] */
+          -ms-transform: translate(0, 0);  /* [12] */
+      -webkit-transform: translate(0, 0);  /* [12] */
+              transform: translate(0, 0);  /* [12] */
     }
   }
 
@@ -101,8 +103,9 @@ $select-animation-speed: $global-animation-speed-fast !default;
     padding-right: $global-spacing-unit+$select-icon-width;  /* [2] */
 
     &::after {
-      -ms-transform: translate(0, 0);  /* [3] */
-      transform: translate(0, 0);  /* [3] */
+          -ms-transform: translate(0, 0);  /* [3] */
+      -webkit-transform: translate(0, 0);  /* [3] */
+              transform: translate(0, 0);  /* [3] */
     }
   }
 

--- a/components/_select.scss
+++ b/components/_select.scss
@@ -2,8 +2,10 @@
    COMPONENTS / SELECT
    ========================================================================== */
 
-// Select settings
-/*
+/* Select settings
+   =========================================== */
+
+/**
 * 1. Should be kept consitant with padding used on .c-btn--select
 */
 $select-border-width: $global-border-width !default;
@@ -70,9 +72,9 @@ $select-animation-speed: $global-animation-speed-fast !default;
     background-size: contain; /* [6] */
     border: solid $select-icon-padding transparent; /* [7] */
     transition: transform $select-animation-speed ease, background-color $select-animation-speed ease; /* [9] */
-        -ms-transform: translate($select-icon-width, 0); /* [9] */
+    -ms-transform: translate($select-icon-width, 0); /* [9] */
     -webkit-transform: translate($select-icon-width, 0); /* [9] */
-            transform: translate($select-icon-width, 0); /* [9] */
+    transform: translate($select-icon-width, 0); /* [9] */
   }
 
   &:focus {
@@ -85,9 +87,9 @@ $select-animation-speed: $global-animation-speed-fast !default;
     padding-right: $select-icon-width / 2 + $select-icon-width;  /* [11] */
 
     &::after {
-          -ms-transform: translate(0, 0);  /* [12] */
+      -ms-transform: translate(0, 0);  /* [12] */
       -webkit-transform: translate(0, 0);  /* [12] */
-              transform: translate(0, 0);  /* [12] */
+      transform: translate(0, 0);  /* [12] */
     }
   }
 
@@ -107,9 +109,9 @@ $select-animation-speed: $global-animation-speed-fast !default;
     padding-right: $select-icon-width / 2 + $select-icon-width;  /* [2] */
 
     &::after {
-          -ms-transform: translate(0, 0);  /* [3] */
+      -ms-transform: translate(0, 0);  /* [3] */
       -webkit-transform: translate(0, 0);  /* [3] */
-              transform: translate(0, 0);  /* [3] */
+      transform: translate(0, 0);  /* [3] */
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sky-toolkit-ui",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "The UI layer of Sky's web toolkit",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
As we should still be supporting iOS8, we need to use vendor prefixes for transforms.  There is potentially a bigger job to add these across the whole toolkit, but this fix focuses on getting the select buttons to look and function correctly. 