### PR TITLE
Removed tick on radio buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1. Bug Fixes
 - [bezel] Added `max-width: 100%` to prevent overflow issues on IE.
+- [forms] Removed tick on selected radio button.
 
 ===
 

--- a/components/_forms.scss
+++ b/components/_forms.scss
@@ -318,6 +318,10 @@ $form-animation-speed: $global-animation-speed-fast;
   background-size: contain;
   background-position: center center;
   border: solid 1px transparent;
+
+  .c-form-checkbox--radio & {
+    background-image: none;
+  }
 }
 
 /* Form modifiers


### PR DESCRIPTION
Fix for tick button appearing on radio button as well as the checkbox component. This will bring the radio buttons inline with the designs.