### PR TITLE
Fix for c-tile link when c-tile--collapsable modifier applied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Toolkit UI v0.5.1
+
+## 1. Bug Fixes
+- [tile] Fix for `.c-tile--collapsable` with nested links breaking on mobile.
+
+===
+
 # Toolkit UI v0.5.0
 
 ## 1. Bug Fixes

--- a/components/_tile.scss
+++ b/components/_tile.scss
@@ -164,6 +164,12 @@ $included-tile-themes: "sky-1", "sky-account", "sky-atlantic", "sky-arts", "sky-
     top: 0;
   }
 
+  .c-tile--collapsable & {
+    @include mq($until: medium) {
+      position: static;
+    }
+  }
+
   &:focus .c-tile__title,
   &:hover .c-tile__title {
     text-decoration: underline;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sky-toolkit-ui",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "The UI layer of Sky's web toolkit",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Description
When `.c-tile--square.c-tile--collapsable` is applied it causes issues with content on smaller devices.

Expected:
![screen shot 2016-09-08 at 15 59 33](https://cloud.githubusercontent.com/assets/2472440/18381173/e14e9c4e-7672-11e6-83ac-c41bddb1b531.png)

Actual:
![screen shot 2016-09-08 at 15 59 20](https://cloud.githubusercontent.com/assets/2472440/18381179/e82c6474-7672-11e6-9413-ea9745c0449b.png)


## Related Issue
Not raised yet

## Motivation and Context
This change will fix the bug by setting the `.c-tile__link` to static positioning so that it correctly adapts height to the content

## How Has This Been Tested?
Browser tested on local dev environment.

Create a tile with `.c-tile.c-tile--square.c-tile--collapsable` and a nested `.c-tile__link`.

## Screenshots (if appropriate):
See above.

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] Changes have been browser tested (including IE).
- [x] I have added instructions on how to test my changes.
- [x] Package version updated.
- [x] CHANGELOG.md updated.
