### PR TITLE
Added relative value for button borders

### DIFF
--- a/components/_buttons.scss
+++ b/components/_buttons.scss
@@ -6,7 +6,7 @@
 $btn-font-size: text(text-lead-small) !default;
 $btn-padding-x: 15px !default;
 $btn-padding-y: 5px !default;
-$btn-border-width: $global-border-width !default;
+$btn-border-width: (strip-unit($global-border-width) / strip-unit($global-font-size)) * 1em !default;
 $btn-border-radius: $global-border-radius !default;
 $btn-animation-speed: $global-animation-speed !default;
 $btn-animation-speed-fast: $global-animation-speed-fast !default;

--- a/components/_buttons.scss
+++ b/components/_buttons.scss
@@ -4,9 +4,9 @@
 
 // Button settings
 $btn-font-size: text(text-lead-small) !default;
-$btn-padding-x: 15px !default;
-$btn-padding-y: 5px !default;
-$btn-border-width: (strip-unit($global-border-width) / strip-unit($global-font-size)) * 1em !default;
+$btn-padding-x: convert-to-em(15px) !default;
+$btn-padding-y: convert-to-em(5px) !default;
+$btn-border-width: convert-to-em($global-border-width) !default;
 $btn-border-radius: $global-border-radius !default;
 $btn-animation-speed: $global-animation-speed !default;
 $btn-animation-speed-fast: $global-animation-speed-fast !default;


### PR DESCRIPTION
## Description
Borders on buttons are currently fixed to 1px, when scaled to larger sizes this doesn't look correct. This introduces an em based border width so that it scales with font-size.

## Related Issue
#90 

## Motivation and Context
Makes buttons handle scaling better

## How Has This Been Tested?
Tested locally on multiple browsers.

## Screenshots (if appropriate):

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] Changes have been browser tested (including IE).
- [x] I have added instructions on how to test my changes.
- [ ] Package version updated.
- [ ] CHANGELOG.md updated.
