### PR TITLE
Feature / Full Tile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Toolkit UI v0.5.1
 
-## 1. Bug Fixes
+## 1. Features
+- [tile] `c-tile--full` for Tiles that utilise a full size image and overlapping title.
+
+## 2. Bug Fixes
+- [buttons] Added relative border to buttons so that the border width scales with font-size.
 - [forms] Fix for `.c-form-checkbox` margin which broke on multi-line captions.
 - [tile] Fix for `.c-tile--collapsable` with nested links breaking on mobile.
 - [shine] Fix for `.c-shine` when using with full width elements.

--- a/components/_tile.scss
+++ b/components/_tile.scss
@@ -33,6 +33,8 @@ $included-tile-themes: "sky-1", "sky-account", "sky-atlantic", "sky-arts", "sky-
 /**
  * The base of the tile; provides the glass "border" and shadow.
  *
+ * The `has-focus` state provides keyboard focus styles for accessiblity.
+ *
  * Also provides selected state, which gives a triangle arrowhead marker between
  * The tile and it's panel.
  *
@@ -46,6 +48,10 @@ $included-tile-themes: "sky-1", "sky-account", "sky-atlantic", "sky-arts", "sky-
   margin-bottom: $global-spacing-unit;
   will-change: transform;
   z-index: 10; /* [1] */
+
+  &.has-focus {
+    box-shadow: 1px 1px 14px 4px rgba(color(highlight), 0.5);
+  }
 
   &.is-selected {
     /**
@@ -142,6 +148,14 @@ $included-tile-themes: "sky-1", "sky-account", "sky-atlantic", "sky-arts", "sky-
     margin-bottom: 0;
   }
 
+  /**
+   * Overlap and stretch body to fit full height on full tiles
+   */
+  .c-tile--full & {
+    position: absolute;
+    height: 100%;
+    top: 0;
+  }
 }
 
 /* Links
@@ -150,11 +164,14 @@ $included-tile-themes: "sky-1", "sky-account", "sky-atlantic", "sky-arts", "sky-
 /**
  * Tiles can have links, just wrap the `.c-tile__content` with a `a.c-tile__link`
  * node.
+ *
+ * Outline is set to "none" to utilise the `.has-focus` state on `c-tile`.
  */
 .c-tile__link {
   display: block;
   color: inherit;
-  transition: color $tile-animation-speed ease;
+  transition: color $tile-animation-speed ease, box-shadow $global-animation-speed-fast ease;
+  outline: none;
 
   .c-tile--square & {
     bottom: 0;
@@ -162,12 +179,6 @@ $included-tile-themes: "sky-1", "sky-account", "sky-atlantic", "sky-arts", "sky-
     position: absolute;
     right: 0;
     top: 0;
-  }
-
-  .c-tile--collapsable & {
-    @include mq($until: medium) {
-      position: static;
-    }
   }
 
   &:focus .c-tile__title,
@@ -199,6 +210,15 @@ $included-tile-themes: "sky-1", "sky-account", "sky-atlantic", "sky-arts", "sky-
       display: none;
     }
   }
+
+  /**
+   * Stretch image to fit full height on full tiles
+   */
+  .c-tile--full & {
+    height: auto;
+    z-index: 10;
+    position: relative;
+  }
 }
 
 /**
@@ -211,6 +231,14 @@ $included-tile-themes: "sky-1", "sky-account", "sky-atlantic", "sky-arts", "sky-
   .c-tile__link:hover & {
     -ms-transform: scale(1.05, 1.05);
     transform: scale(1.05, 1.05);
+  }
+
+  /**
+   * Align to center on full tiles
+   */
+  .c-tile--full & {
+    display: block;
+    margin: 0 auto;
   }
 }
 
@@ -231,7 +259,24 @@ $included-tile-themes: "sky-1", "sky-account", "sky-atlantic", "sky-arts", "sky-
       height: auto;
     }
   }
+}
 
+/**
+ * Overlays are needed for full tiles, overlapping the tile content to take up
+ * the lower side of the tile.
+ */
+.c-tile__overlay {
+  position: absolute;
+  text-align: center;
+  bottom: 0;
+  left: 1em;
+  right: 1em;
+  height: 20%;
+  z-index: 20;
+
+  &--large {
+    height: 25%;
+  }
 }
 
 /* Titles
@@ -256,6 +301,14 @@ $included-tile-themes: "sky-1", "sky-account", "sky-atlantic", "sky-arts", "sky-
 
   @include mq($from: large) {
     font-size: text(heading-charlie);
+  }
+
+  .c-tile--full & {
+    font-size: text(heading-delta);
+
+    @include mq($from: medium, $until: large) {
+      font-size: 2.8vw;
+    }
   }
 }
 
@@ -336,13 +389,12 @@ $included-tile-themes: "sky-1", "sky-account", "sky-atlantic", "sky-arts", "sky-
     z-index: -1; // Set between before and content.
   }
 
-  .c-tile__link:hover &::after,
-  .c-tile__link:focus &::after {
+  .c-tile__link:hover &::after {
     opacity: 1; // Set hover opacity
   }
 }
 
-// Styling for default tiles without images
+// Styling for default tiles
 .c-tile__body {
   &::before {
     @include background-gradient($tile-gradient-default, "radial");
@@ -352,13 +404,23 @@ $included-tile-themes: "sky-1", "sky-account", "sky-atlantic", "sky-arts", "sky-
   }
 }
 
-// Styling for default tiles with images
+// Styling for default tiles (with split image)
 .c-tile__caption {
   &::before {
     @include background-gradient($tile-gradient-default);
   }
   .c-tile__link &::after {
     @include background-gradient($tile-gradient-default-hover);
+  }
+}
+
+// Styling for full tiles
+.c-tile--full .c-tile__body {
+  &::before {
+    background: color(white);
+  }
+  &::after {
+    @include background-gradient(mid, vertical-invert, 0% 50%);
   }
 }
 
@@ -377,11 +439,11 @@ $included-tile-themes: "sky-1", "sky-account", "sky-atlantic", "sky-arts", "sky-
 }
 
 .c-tile__shine--top {
-  top: -($global-spacing-unit-small);
+  top: -($global-spacing-unit-small + $tile-border-width);
 }
 
 .c-tile__shine--bottom {
-  bottom: -($global-spacing-unit-small + $tile-border-width); // Offset for asymmetric shine graphic.
+  bottom: -($global-spacing-unit-small + $tile-border-width);
 }
 
 /* Tile themes


### PR DESCRIPTION
**Dependant on https://github.com/sky-uk/toolkit-core/pull/115**

Full Tile styles.

## Description
`.c-tile--full` for tiles that use images without a split. These tiles are white and use a new gradient on hover. `.has-focus` state for keyboard navigation.

## Related Issue
https://github.com/sky-uk/toolkit-ui/issues/128

## Motivation and Context
Cleaner design and accessibility improvements using `.has-focus`.

## How Has This Been Tested?
Tests pass on `npm run test`.
Visually checked in all browsers.

## Screenshots (if appropriate):
Achieves the following styles:
<img width="1424" alt="screen shot 2016-09-12 at 11 33 59" src="https://cloud.githubusercontent.com/assets/7349341/18433178/116677f4-78de-11e6-9cef-1fcaf966e0a0.png">

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] ~~Bug fix (non-breaking change which fixes an issue)~~
- [x] New feature (non-breaking change which adds functionality)
- [x] ~~Breaking change (fix or feature that would cause existing functionality to change)~~

## Checklist:

- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] Changes have been browser tested (including IE).
- [x] I have added instructions on how to test my changes.
