### PR TITLE
Added fix for accordion icon alignment in IE9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [tile] `c-tile--full` for Tiles that utilise a full size image and overlapping title.
 
 ## 2. Bug Fixes
+- [accordion] Fixed arrow icon alignment in IE9.
 - [buttons] Added relative border to buttons so that the border width scales with font-size.
 - [buttons] Added `:focus` styles for accessibility.
 - [forms] Fix for `.c-form-checkbox` margin which broke on multi-line captions.

--- a/components/_accordion.scss
+++ b/components/_accordion.scss
@@ -65,19 +65,17 @@ $accordion-icon-size: 20px !default;
   /**
    * Accordion icons provide an extra form of 'toggle' indication.
    *
-   * 1. Allows for absolute positioning from the top and right of the label.
+   * 1. Allows for absolute positioning from the top (minus half the height of
+   *    the icon) and right of the label.
    * 2. Sets the icon size.
    * 3. Sets background-image to the icon as Base64.
    * 4. Prevents the pseudo-element partially blocking the label's click events.
-   * 5. Sets a starting position for the icon's movement.
-   *    translateY is required to align the absolute icon to 50% of the height.
-   *    translateZ is required to prevent pixel jumps in webkit browsers.
-   * 6. Animates the transform property on transition.
+   * 5. Animates the transform property on transition.
    */
   &::after {
     content: "";
     position: absolute; /* [1] */
-    top: 50%; /* [1] */
+    top: calc(50% - ($accordion-icon-size / 2)); /* [1] */
     right: $accordion-icon-size; /* [1] */
     width: $accordion-icon-size; /* [2] */
     height: $accordion-icon-size; /* [2] */
@@ -86,8 +84,7 @@ $accordion-icon-size: 20px !default;
     background-size: contain; /* [3] */
     background-position: center center; /* [3] */
     pointer-events: none; /* [4] */
-    transform: translateZ(0) translateY(-50%) rotate(0); /* [5] */
-    transition: transform $accordion-animation-speed ease; /* [6] */
+    transition: transform $accordion-animation-speed ease; /* [5] */
   }
 }
 
@@ -132,7 +129,8 @@ $accordion-icon-size: 20px !default;
    */
   .c-accordion__label {
     &::after {
-      transform: translateZ(0) translateY(-50%) rotate(180deg);
+      -ms-transform: rotate(180deg);
+      transform: rotate(180deg);
     }
   }
 }

--- a/components/_accordion.scss
+++ b/components/_accordion.scss
@@ -75,7 +75,7 @@ $accordion-icon-size: 20px !default;
   &::after {
     content: "";
     position: absolute; /* [1] */
-    top: calc(50% - ($accordion-icon-size / 2)); /* [1] */
+    top: calc(50% - #{$accordion-icon-size / 2}); /* [1] */
     right: $accordion-icon-size; /* [1] */
     width: $accordion-icon-size; /* [2] */
     height: $accordion-icon-size; /* [2] */

--- a/components/_accordion.scss
+++ b/components/_accordion.scss
@@ -65,17 +65,19 @@ $accordion-icon-size: 20px !default;
   /**
    * Accordion icons provide an extra form of 'toggle' indication.
    *
-   * 1. Allows for absolute positioning from the top (minus half the height of
-   *    the icon) and right of the label.
+   * 1. Allows for absolute positioning from the top and right of the label.
    * 2. Sets the icon size.
    * 3. Sets background-image to the icon as Base64.
    * 4. Prevents the pseudo-element partially blocking the label's click events.
-   * 5. Animates the transform property on transition.
+   * 5. Sets a starting position for the icon's movement.
+   *    translateY is required to align the absolute icon to 50% of the height.
+   *    translateZ is required to prevent pixel jumps in webkit browsers.
+   * 6. Animates the transform property on transition.
    */
   &::after {
     content: "";
     position: absolute; /* [1] */
-    top: calc(50% - #{$accordion-icon-size / 2}); /* [1] */
+    top: 50%; /* [1] */
     right: $accordion-icon-size; /* [1] */
     width: $accordion-icon-size; /* [2] */
     height: $accordion-icon-size; /* [2] */
@@ -84,7 +86,9 @@ $accordion-icon-size: 20px !default;
     background-size: contain; /* [3] */
     background-position: center center; /* [3] */
     pointer-events: none; /* [4] */
-    transition: transform $accordion-animation-speed ease; /* [5] */
+    -ms-transform: translateY(-50%) rotate(0); /* [5] */
+    transform: translateY(-50%) rotate(0); /* [5] */
+    transition: transform $accordion-animation-speed ease; /* [6] */
   }
 }
 
@@ -129,8 +133,8 @@ $accordion-icon-size: 20px !default;
    */
   .c-accordion__label {
     &::after {
-      -ms-transform: rotate(180deg);
-      transform: rotate(180deg);
+      -ms-transform: translateY(-50%) rotate(180deg);
+      transform: translateY(-50%) rotate(180deg);
     }
   }
 }


### PR DESCRIPTION
## Description
Added fix for icon vertical alignment

## Related Issue
#148

## Motivation and Context
Display issue on IE9

## How Has This Been Tested?
Browser tested on IE9, Chrome and Safari etc via `blackjack-accordion`

## Screenshots (if appropriate):

Before:
<img width="719" alt="screen shot 2016-09-16 at 14 26 08" src="https://cloud.githubusercontent.com/assets/2472440/18587554/9258f5f0-7c1a-11e6-9e59-8da5e7d052ae.png">

After:
<img width="756" alt="screen shot 2016-09-16 at 14 16 41" src="https://cloud.githubusercontent.com/assets/2472440/18587559/999d57f2-7c1a-11e6-849f-4346304a0203.png">


## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] Changes have been browser tested (including IE).
- [x] I have added instructions on how to test my changes.
- [ ] Package version updated.
- [ ] CHANGELOG.md updated.