### PR TITLE
Focus styles for Buttons and Select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@
 
 ## 2. Bug Fixes
 - [buttons] Added relative border to buttons so that the border width scales with font-size.
+- [buttons] Added `:focus` styles for accessibility.
 - [forms] Fix for `.c-form-checkbox` margin which broke on multi-line captions.
 - [tile] Fix for `.c-tile--collapsable` with nested links breaking on mobile.
 - [shine] Fix for `.c-shine` when using with full width elements.
+- [select] Added `:focus` styles for accessibility.
 
 ===
 

--- a/components/_buttons.scss
+++ b/components/_buttons.scss
@@ -8,6 +8,11 @@ $btn-padding-x: convert-to-em(15px) !default;
 $btn-padding-y: convert-to-em(5px) !default;
 $btn-border-width: convert-to-em($global-border-width) !default;
 $btn-border-radius: $global-border-radius !default;
+$btn-box-shadow-fg: 0 1px 3px !default;
+$btn-box-shadow-bg: 0 1px 15px 3px !default;
+$btn-box-shadow: $btn-box-shadow-fg rgba(color(black), 0), $btn-box-shadow-bg rgba(color(black), 0) !default;
+$btn-box-shadow-focus: $btn-box-shadow-fg rgba(color(black), 0.4), $btn-box-shadow-bg rgba(color(highlight), 0.75) !default;
+$btn-box-shadow-focus-invert: $btn-box-shadow-fg rgba(color(black), 0.75), $btn-box-shadow-bg rgba(color(white), 0.5) !default;
 $btn-animation-speed: $global-animation-speed !default;
 $btn-animation-speed-fast: $global-animation-speed-fast !default;
 
@@ -25,9 +30,10 @@ $btn-animation-speed-fast: $global-animation-speed-fast !default;
  * 9.  Remove anchor text-decoration (necessary when styling `a`s as buttons).
  * 10. Base transparent border for modifers to alter.
  * 11. Set default button border-radius.
- * 12. Set default button transition (color, background-color and border-color)
- * 13. Force all button-styled elements to appear clickable.
- * 14. Remove browser outline styles.
+ * 12. Set base transparent box-shadow to animate upon.
+ * 13. Set default button transition (color, background-color, border-color and box-shadow)
+ * 14. Force all button-styled elements to appear clickable.
+ * 15. Remove browser outline styles.
  */
 .c-btn {
   display: inline-block; /* [1] */
@@ -41,9 +47,10 @@ $btn-animation-speed-fast: $global-animation-speed-fast !default;
   text-decoration: none; /* [9] */
   border: $btn-border-width solid transparent; /* [10] */
   border-radius: $btn-border-radius; /* [11] */
-  transition: color $btn-animation-speed ease, background-color $btn-animation-speed ease, border-color $btn-animation-speed ease; /* [12] */
-  cursor: pointer; /* [13] */
-  outline: none; /* [14] */
+  box-shadow: $btn-box-shadow; /* [12] */
+  transition: color $btn-animation-speed ease, background-color $btn-animation-speed ease, border-color $btn-animation-speed ease, box-shadow $btn-animation-speed ease; /* [13] */
+  cursor: pointer; /* [14] */
+  outline: none; /* [15] */
 
   &:hover,
   &:active,
@@ -73,10 +80,13 @@ $btn-animation-speed-fast: $global-animation-speed-fast !default;
   border-color: color(brand);
 
   &:hover,
-  &:active,
-  &:focus {
+  &:active {
     background-color: color(highlight);
     border-color: color(highlight);
+  }
+
+  &:focus {
+    box-shadow: $btn-box-shadow-focus;
   }
 }
 
@@ -89,11 +99,14 @@ $btn-animation-speed-fast: $global-animation-speed-fast !default;
   border-color: color(brand);
 
   &:hover,
-  &:active,
-  &:focus {
+  &:active {
     color: color(white);
     background-color: color(highlight);
     border-color: color(highlight);
+  }
+
+  &:focus {
+    box-shadow: $btn-box-shadow-focus;
   }
 }
 
@@ -107,11 +120,14 @@ $btn-animation-speed-fast: $global-animation-speed-fast !default;
   border-color: color(white);
 
   &:hover,
-  &:active,
-  &:focus {
+  &:active {
     color: color(text);
     background-color: color(white);
     border-color: color(white);
+  }
+
+  &:focus {
+    box-shadow: $btn-box-shadow-focus-invert;
   }
 }
 

--- a/components/_buttons.scss
+++ b/components/_buttons.scss
@@ -50,12 +50,12 @@ $btn-animation-speed-fast: $global-animation-speed-fast !default;
   box-shadow: $btn-box-shadow; /* [12] */
   transition: color $btn-animation-speed ease, background-color $btn-animation-speed ease, border-color $btn-animation-speed ease, box-shadow $btn-animation-speed ease; /* [13] */
   cursor: pointer; /* [14] */
-  outline: none; /* [15] */
 
   &:hover,
   &:active,
   &:focus {
     text-decoration: none; /* [9] */
+    outline: none; /* [15] */
   }
 
 }

--- a/components/_select.scss
+++ b/components/_select.scss
@@ -13,23 +13,17 @@ $select-border-radius: $global-border-radius !default;
 $select-icon-padding: $global-spacing-unit-tiny !default;
 $select-icon-width: 40px !default; /* [1] */
 $select-animation-speed: $global-animation-speed-fast !default;
+$select-box-shadow-focus: $btn-box-shadow-focus !default;
 
 /**
  * 1. Allows styling of box model properties.
  * 2. Allows absolute positioning of child pseudo-elements.
  * 3. Prevent overlap of border-radius by border-width.
- * 4. Hide overflow to prevent any transitions from leaking.
- * 5. Provide a slighly larger border-radius than buttons to neaten the
- *    overflow corners.
- * 6. Fixes Chrome bug that prevents border-radius affecting the overflow.
  */
 .c-select {
   display: inline-block; /* [1] */
   position: relative; /* [2] */
   padding-left: $select-border-width; /* [3] */
-  overflow: hidden; /* [4] */
-  border-radius: $select-border-radius; /* [5] */
-  perspective: 1px; /* [6] */
 }
 
 /**
@@ -53,6 +47,7 @@ $select-animation-speed: $global-animation-speed-fast !default;
   display: block;
   position: relative;
   border: $select-border-width solid color(brand);
+  overflow: hidden;
 
   &::after {
     content: ""; /* [1] */
@@ -82,7 +77,10 @@ $select-animation-speed: $global-animation-speed-fast !default;
 .c-select__input {
   @include hide-visually();
 
-  &:focus + .c-select__btn,
+  &:focus + .c-select__btn {
+    box-shadow: $select-box-shadow-focus;
+  }
+
   &:hover + .c-select__btn {
     border-color: color(highlight);
   }


### PR DESCRIPTION
New styles that implement `:focus` to improve accessibility

## Description
Extra "box-shadow glow" for buttons and select when in `:focus`.

## Related Issue
https://github.com/sky-uk/toolkit-ui/issues/41
https://github.com/sky-uk/toolkit-ui/issues/145

## Motivation and Context
Significantly improves accessibility and keyboard UX.

## How Has This Been Tested?
Visual and manual use checks in:
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Opera
- [x] IE9

## Screenshots (if appropriate):
<img width="1069" alt="b" src="https://cloud.githubusercontent.com/assets/7349341/18588068/da2ebc64-7c1c-11e6-8d1c-3232ba6b308a.png">

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] ~~New feature (non-breaking change which adds functionality)~~
- [x] ~~Breaking change (fix or feature that would cause existing functionality to change)~~

## Checklist:

- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] Changes have been browser tested (including IE).
- [x] I have added instructions on how to test my changes.
- [x] Package version updated.
- [x] CHANGELOG.md updated.
