### PR TITLE
Added fix for tile media height rounding down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [buttons] Added `:focus` styles for accessibility.
 - [forms] Fix for `.c-form-checkbox` margin which broke on multi-line captions.
 - [tile] Fix for `.c-tile--collapsable` with nested links breaking on mobile.
+- [tile] Fix for `.c-tile__media` height rounding down incorrectly causing a 1px gap.
 - [shine] Fix for `.c-shine` when using with full width elements.
 - [select] Added `:focus` styles for accessibility.
 

--- a/components/_tile.scss
+++ b/components/_tile.scss
@@ -200,7 +200,7 @@ $included-tile-themes: "sky-1", "sky-account", "sky-atlantic", "sky-arts", "sky-
 .c-tile__media {
   overflow: hidden;
   display: block;
-  height: 55%;
+  height: 55.5%; // Fixes issue with rounding down of height leaving a gap.
 
   /**
    * Hide media below medium on collapsable tiles


### PR DESCRIPTION
## Description
At certain resolutions the `.c-tile__media` 55% height was being rounded down causing a gap to appear between it and the caption below, adjusting this to 55.5% ensures this doesn't happen:

*Before:*
![screen shot 2016-09-19 at 13 00 20](https://cloud.githubusercontent.com/assets/2472440/18631310/2ac50586-7e69-11e6-8db6-d7386aa295f8.png)

*After:*
![screen shot 2016-09-19 at 13 00 48](https://cloud.githubusercontent.com/assets/2472440/18631316/3076198e-7e69-11e6-9501-01db4ed7872f.png)


## Related Issue
Please link to the issue here:

## Motivation and Context
Fixes visual bug seen across all tiles.

## How Has This Been Tested?
Tested on local browsers

## Screenshots (if appropriate):
See description

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.