### PR TITLE
Shadow fix for Panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [buttons] Added relative border to buttons so that the border width scales with font-size.
 - [buttons] Added `:focus` styles for accessibility.
 - [forms] Fix for `.c-form-checkbox` margin which broke on multi-line captions.
+- [panel] Inset shadow fix from all sides to top and bottom only.
 - [tile] Fix for `.c-tile--collapsable` with nested links breaking on mobile.
 - [shine] Fix for `.c-shine` when using with full width elements.
 - [select] Added `:focus` styles for accessibility.

--- a/components/_panel.scss
+++ b/components/_panel.scss
@@ -3,11 +3,13 @@
    ========================================================================== */
 
 // Panel settings
-$panel-shadow-size: inset 0 0 12px 0;
+//$panel-shadow-size: inset 0 0 12px 0;
+$panel-shadow-size-top: inset 0 12px 12px -12px;
+$panel-shadow-size-bottom: inset 0 -12px 12px -12px;
 $panel-shadow-color: #9f9f9f;
 $panel-shadow-color-dark: color(black);
-$panel-shadow: $panel-shadow-size $panel-shadow-color;
-$panel-shadow-dark: $panel-shadow-size $panel-shadow-color-dark;
+$panel-shadow: $panel-shadow-size-top $panel-shadow-color, $panel-shadow-size-bottom $panel-shadow-color;
+$panel-shadow-dark: $panel-shadow-size-top $panel-shadow-color-dark, $panel-shadow-size-bottom $panel-shadow-color-dark;
 $panel-background-color: color(white) !default;
 $panel-background-color-dark: color(ui-dark) !default;
 


### PR DESCRIPTION
## Description
Sets shadow on the top and bottom of panel, rather than all sides.

## Related Issue
https://github.com/sky-uk/toolkit-ui/issues/155
cc @aaronthomas 

## Motivation and Context
Corrected to follow brand guidelines

## How Has This Been Tested?
Visual and manual use checks in:
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Opera
- [x] IE9

## Screenshots (if appropriate):
<img width="1425" alt="screen shot 2016-09-19 at 16 10 43" src="https://cloud.githubusercontent.com/assets/7349341/18637260/bce942aa-7e83-11e6-95e3-6308bcc08ef7.png">

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] ~~New feature (non-breaking change which adds functionality)~~
- [x] ~~Breaking change (fix or feature that would cause existing functionality to change)~~

## Checklist:

- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] Changes have been browser tested (including IE).
- [x] I have added instructions on how to test my changes.
- [x] ~~Package version updated.~~
- [x] CHANGELOG.md updated.
