### PR TITLE
Added fix for positioning of select text content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [tile] Fix for `.c-tile__media` height rounding down incorrectly causing a 1px gap.
 - [shine] Fix for `.c-shine` when using with full width elements.
 - [select] Added `:focus` styles for accessibility.
+- [select] Fixed spacing of text.
 
 ===
 

--- a/components/_forms.scss
+++ b/components/_forms.scss
@@ -229,6 +229,7 @@ $form-animation-speed: $global-animation-speed-fast;
 
 .c-form-select {
   @include font-size($form-font-size, large);
+  line-height: 1.2;
   display: inline-block;
   margin-bottom: $global-spacing-unit-tiny;
   position: relative;
@@ -254,13 +255,11 @@ $form-animation-speed: $global-animation-speed-fast;
 }
 
 .c-form-select__dropdown {
-  @include font-size($form-font-size, large);
-  padding: $global-spacing-unit-tiny/2 $global-spacing-unit-tiny;
+  padding: $global-spacing-unit-tiny $global-spacing-unit-tiny;
   width: 100%;
   border: $form-border;
   background-color: $form-background;
   box-shadow: $form-shadow;
-  line-height: 1.2em;
   transition: box-shadow $form-animation-speed ease, border-color $form-animation-speed ease;
   outline: 0;
   cursor: pointer;

--- a/components/_forms.scss
+++ b/components/_forms.scss
@@ -260,6 +260,7 @@ $form-animation-speed: $global-animation-speed-fast;
   border: $form-border;
   background-color: $form-background;
   box-shadow: $form-shadow;
+  line-height: 1.2em;
   transition: box-shadow $form-animation-speed ease, border-color $form-animation-speed ease;
   outline: 0;
   cursor: pointer;


### PR DESCRIPTION
## Description
Fixed issue with spacing of text within toolkit select in Chrome.


## Related Issue
#157


## Motivation and Context
This fixes an issue with select contents having no bottom spacing and on occasion being cropped.

**Before:**
<img width="586" alt="screen shot 2016-09-22 at 14 23 48" src="https://cloud.githubusercontent.com/assets/2472440/18749803/6930adac-80d0-11e6-8470-9fe5a4538140.png">

<img width="688" alt="screen shot 2016-09-22 at 14 23 23" src="https://cloud.githubusercontent.com/assets/2472440/18749810/6e815fd6-80d0-11e6-8783-df21b6bc779a.png">

**After:**
<img width="438" alt="screen shot 2016-09-22 at 14 26 16" src="https://cloud.githubusercontent.com/assets/2472440/18749835/8d3dc05e-80d0-11e6-9342-b317d47f041c.png">


## How Has This Been Tested?
Tested locally across major browsers.


## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] All new and existing tests passed.
- [x] Changes have been browser tested (including IE).
- [x] CHANGELOG.md updated.
