### PR TITLE
Dropdown Menu Refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@
 - [divider] `c-divider` for prominent horizontal (and vertical) rules for use between elements.
 - [tile] `c-tile--full` for Tiles that utilise a full size image and overlapping title.
 
-## 2. Bug Fixes
+## 2. Refactor
+- [dropdown] No longer utilises a checkbox hack, improving semantic structure and accessibility. Now implements a stateful `.is-open` class.
+
+## 3. Bug Fixes
 - [accordion] Fixed arrow icon alignment in IE9.
 - [buttons] Added relative border to buttons so that the border width scales with font-size.
 - [buttons] Added `:focus` styles for accessibility.

--- a/components/_dropdown.scss
+++ b/components/_dropdown.scss
@@ -30,39 +30,30 @@ $dropdown-shadow-focus: 0 0 $dropdown-shadow-blur-radius 0 rgba(0, 0, 0, 0.2) !d
  *
  * 1. Set font-size and line-height
  * 2. Displays the label stacked above its menu items.
- * 3. Allows absolute positioning of child pseudo-elements.
- * 4. Set the label font-weight to bold.
- * 5. Sets padding on top, left and bottom whilst providing extra padding on the
+ * 3. Sets padding on top, left and bottom whilst providing extra padding on the
  *    right for the icon.
- * 6. Sets a border to the label to mimic a button appearance.
- * 7. Sets a border-radius to the label to mimic a button appearance.
- * 8. Sets a background-color to the label to mimic a button appearance.
- * 9. Removes any browser default outline styles
- * 10. Forces the cursor to a "clickable" pointer state.
- * 11. Sets stacking order for the menu items to overlap above the label
- *     (essential for the shadow overlap fix)
- * 12. Sets animation settings on transition.
+ * 4. Sets stacking order for the menu items to overlap above the label
+ *    (essential for the shadow overlap fix)
  */
-.c-dropdown__label {
+.c-dropdown__toggle {
   @include font-size(text-lead-small); /* [1] */
   display: block; /* [2] */
-  position: relative; /* [3] */
-  font-weight: bold; /* [4] */
-  padding: $global-spacing-unit-tiny/2 $global-spacing-unit-large $global-spacing-unit-tiny/2 $global-spacing-unit-small; /* [5] */
-  border: $dropdown-border; /* [6] */
-  border-radius: $dropdown-border-radius; /* [7] */
-  background-color: $dropdown-background; /* [8] */
-  outline: 0; /* [9] */
-  cursor: pointer; /* [10] */
-  z-index: 1; /* [11] */
-  transition: all $dropdown-animation-speed ease; /* [12] */
+  position: relative;
+  font-weight: bold;
+  padding: $global-spacing-unit-tiny/2 $global-spacing-unit-large $global-spacing-unit-tiny/2 $global-spacing-unit-small; /* [3] */
+  border: $dropdown-border;
+  border-radius: $dropdown-border-radius;
+  color: color(text);
+  background-color: $dropdown-background;
+  outline: 0;
+  cursor: pointer;
+  z-index: 1; /* [4] */
+  transition: all $dropdown-animation-speed ease;
 
   /**
    * The Dropdown label uses an icon to indicate when the menu has been toggled.
    * N.B. Temporary use of Base64 until a Sky SVG solution is realised.
    *
-   * 1. Sets content to empty.
-   * 2. Allows for greater control of positioning.
    * 3. Allows for positioning from the top and right of the dropdown.
    * 4. Set the icon size.
    * 5. Sets background-image to the icon as Base64.
@@ -92,38 +83,31 @@ $dropdown-shadow-focus: 0 0 $dropdown-shadow-blur-radius 0 rgba(0, 0, 0, 0.2) !d
 /**
  * The Dropdown list contains menu items, appearing when the label is toggled.
  *
- * 1. Allows the list to appear stacked underneath the label.
- * 2. Allows for greater control of positioning.
- * 3. Removes default list margins.
- * 4. Sets the list to be stacked above the the label.
+ * 1. Removes default list margins.
+ * 2. Sets the list to be stacked above the the label.
  *    This is essential for the list's pseudo-element overlap fix.
- * 5. Removes default list bullets/numbers.
- * 6. Sets a background-color to compliment the label's appearance.
- * 7. Sets a border-radius on the bottom of the list to compliment the
+ * 3. Sets a border-radius on the bottom of the list to compliment the
  *    label's appearance.
- * 8. Sets a base box-shadow to animate and compliment the label.
- * 9. Visually hides the dropdown list until toggled.
- * 10. Sets a base scaleY to animate.
- * 11. Sets the transform to animate from the top of the element.
- * 12. Compliments the opacity to visually hide the dropdown list.
- * 13. Sets animation settings on transition.
+ * 4. Visually hides the dropdown list until toggled.
+ * 5. Sets a base scaleY to animate.
+ * 6. Sets the transform to animate from the top of the element.
  */
 .c-dropdown__list {
-  display: block; /* [1] */
-  width: 100%; /* [1] */
-  position: absolute; /* [2] */
-  margin: 0; /* [3] */
-  z-index: 2; /* [4] */
+  display: block;
+  width: 100%;
+  position: absolute;
+  margin: 0; /* [1] */
+  z-index: 2; /* [2] */
   list-style-type: none; /* [5] */
-  background-color: $dropdown-background; /* [6] */
-  border-radius: 0 0 $dropdown-border-radius $dropdown-border-radius; /* [7] */
-  box-shadow: $dropdown-shadow-focus; /* [8] */
-  opacity: 0; /* [9] */
-  -ms-transform: scaleY(0); /* [10] */
-  transform: scaleY(0); /* [10] */
-  -ms-transform-origin: top; /* [11] */
-  transform-origin: top; /* [11] */
-  visibility: hidden; /* [12] */
+  background-color: $dropdown-background;
+  border-radius: 0 0 $dropdown-border-radius $dropdown-border-radius; /* [3] */
+  box-shadow: $dropdown-shadow-focus;
+  opacity: 0; /* [4] */
+  -ms-transform: scaleY(0); /* [5] */
+  transform: scaleY(0); /* [5] */
+  -ms-transform-origin: top; /* [6] */
+  transform-origin: top; /* [6] */
+  visibility: hidden; /* [4] */
   transition: all $dropdown-animation-speed ease; /* [13] */
 
   /**
@@ -131,20 +115,17 @@ $dropdown-shadow-focus: 0 0 $dropdown-shadow-blur-radius 0 rgba(0, 0, 0, 0.2) !d
    * inevitably be overlap. To prevent this overlap, the Dropdown list uses a
    * pseudo-element with a matching background-color to cover the shadow.
    *
-   * 1. Sets content to empty.
-   * 2. Allows for greater control of positioning.
-   * 3. Allows for the pseudo-element to stack above the list and fill width.
-   * 4. Sets height and positioning to match and cover the shadow's blur radius.
-   * 5. Matches the Dropdown label background to hide the shadow.
+   * 1. Sets height and positioning to match and cover the shadow's blur radius.
+   * 2. Matches the Dropdown label background to hide the shadow.
    */
   &::before {
-    content: ""; /* [1] */
-    position: absolute; /* [2] */
-    display: block; /* [3] */
-    width: 100%; /* [3] */
-    height: $dropdown-shadow-blur-radius; /* [4] */
-    top: -$dropdown-shadow-blur-radius; /* [4] */
-    background-color: $dropdown-background; /* [5] */
+    content: "";
+    position: absolute;
+    display: block;
+    width: 100%;
+    height: $dropdown-shadow-blur-radius; /* [1] */
+    top: -$dropdown-shadow-blur-radius; /* [1] */
+    background-color: $dropdown-background; /* [2] */
   }
 }
 
@@ -152,86 +133,71 @@ $dropdown-shadow-focus: 0 0 $dropdown-shadow-blur-radius 0 rgba(0, 0, 0, 0.2) !d
  * The Dropdown link class provides styling for individual menu items within the
  * Dropdown list.
  *
- * 1. Set font-size and line-height
- * 2. Allows menu items to be stacked on top of eachother.
- * 3. Provides padding to compliment the label.
- * 4. Overides default link color.
- * 5. As we use scaleY on the Dropdown list to toggle the menu, each item is
+ * 1. Overides default link color.
+ * 2. As we use scaleY on the Dropdown list to toggle the menu, each item is
  *    scaled slightly larger at the start to counteract the Dropdown list scaleY
  *    and prevent a "squashed" appearance on toggle.
- * 6. Allows us to transition the link opacity slightly faster than the list.
- * 7. Animates the transform and opacity property on transition.
- * 8. Sets background color to appear darker on hover and focus.
- * 9. As we can't hide the overflow, a border-radius is set on the last-child.
+ * 3. Allows us to transition the link opacity slightly faster than the list.
+ * 4. As we can't hide the overflow, a border-radius is set on the last-child.
  */
 .c-dropdown__link {
-  @include font-size(text-lead-small); /* [1] */
-  display: block; /* [2] */
-  width: 100%; /* [2] */
-  padding: $global-spacing-unit-tiny/2 $global-spacing-unit-small; /* [3] */
-  color: color(text); /* [4] */
-  -ms-transform: scaleY(2.5); /* [5] */
-  transform: scaleY(2.5); /* [5] */
-  opacity: 0; /* [6] */
-  transition: transform $dropdown-animation-speed ease, opacity $global-animation-speed-fast ease; /* [7] */
+  @include font-size(text-lead-small);
+  display: block;
+  width: 100%;
+  padding: $global-spacing-unit-tiny/2 $global-spacing-unit-small;
+  color: color(text); /* [1] */
+  -ms-transform: scaleY(2.5); /* [2] */
+  transform: scaleY(2.5); /* [2] */
+  opacity: 0; /* [3] */
+  transition: transform $dropdown-animation-speed ease, opacity $global-animation-speed-fast ease;
 
   &:hover,
   &:focus {
-    background-color: $dropdown-background-focus; /* [8] */
+    background-color: $dropdown-background-focus;
   }
 
   &:last-child {
-    border-radius: 0 0 $dropdown-border-radius $dropdown-border-radius; /* [9] */
+    border-radius: 0 0 $dropdown-border-radius $dropdown-border-radius; /* [4] */
   }
 }
 
 /**
- * The Dropdown input is essential for the Dropdown's functionality, allowing
- * the list to be toggled through a hidden checkbox input.
- *
- * 1. Hides the checkbox input.
-*/
-.c-dropdown__input {
-  display: none; /* [1] */
-
+ * Dropdown on toggle.
+ */
+.c-dropdown.is-open {
   /**
    * Dropdown list on toggle.
    *
-   * 1. Shows the dropdown list.
-   * 2. Scales vertical axis to its full height to achieve 'slide' animation.
-   * 3. Sets the content to visible.
-   * 4. Sets text to its correct height.
-   * 5. Sets text to display.
+   * 1. Scales vertical axis to its full height to achieve 'slide' animation.
+   * 2. Sets text to its correct height to animate upon.
   */
-  &:checked ~ .c-dropdown__list {
-    opacity: 1; /* [1] */
+  .c-dropdown__list {
+    opacity: 1;
+    -ms-transform: scaleY(1); /* [1] */
+    transform: scaleY(1); /* [1] */
+    visibility: visible;
+  }
+
+  .c-dropdown__link {
     -ms-transform: scaleY(1); /* [2] */
     transform: scaleY(1); /* [2] */
-    visibility: visible; /* [3] */
-
-    .c-dropdown__link {
-      -ms-transform: scaleY(1); /* [4] */
-      transform: scaleY(1); /* [4] */
-      opacity: 1; /* [5] */
-    }
+    opacity: 1;
   }
 
   /**
    * Dropdown label on toggle.
    *
-   * 1. Sets border-color to match background color.
-   * 2. Sets box-shadow to an active state.
-   * 3. Removes border-radius on bottom edge to overlap the dropdown list.
-   * 4. Rotates icon indicator 180 degrees.
+   * 1. Removes border-radius on bottom edge to overlap the dropdown list.
+   * 2. Rotates icon indicator 180 degrees.
   */
-  &:checked ~ .c-dropdown__label {
+  .c-dropdown__toggle {
     border-color: $dropdown-background;
     box-shadow: $dropdown-shadow-focus;
-    border-radius: $dropdown-border-radius $dropdown-border-radius 0 0;
+    border-radius: $dropdown-border-radius $dropdown-border-radius 0 0; /* [1] */
 
     &::after {
-      -ms-transform: translateZ(0) rotate(180deg);
-      transform: translateZ(0) rotate(180deg);
+      -ms-transform: translateZ(0) rotate(180deg); /* [2] */
+      transform: translateZ(0) rotate(180deg); /* [2] */
     }
   }
 }

--- a/components/_dropdown.scss
+++ b/components/_dropdown.scss
@@ -49,7 +49,7 @@ $dropdown-focus: 1px 3px rgba(color(black), 0.4), 0 1px 15px 3px rgba(color(high
   outline: 0;
   cursor: pointer;
   z-index: 1; /* [4] */
-  transition: all $dropdown-animation-speed ease;
+  transition: border $dropdown-animation-speed ease, border-radius $dropdown-animation-speed ease, box-shadow $dropdown-animation-speed ease;
 
   &:focus {
     box-shadow: $dropdown-focus;

--- a/components/_dropdown.scss
+++ b/components/_dropdown.scss
@@ -10,7 +10,8 @@ $dropdown-border: 1px solid color(keyline) !default;
 $dropdown-border-radius: $global-border-radius !default;
 $dropdown-shadow-blur-radius: 8px !default;
 $dropdown-shadow: 0 0 0 0 rgba(0, 0, 0, 0.2) !default;
-$dropdown-shadow-focus: 0 0 $dropdown-shadow-blur-radius 0 rgba(0, 0, 0, 0.2) !default;
+$dropdown-shadow-active: 0 0 $dropdown-shadow-blur-radius 0 rgba(0, 0, 0, 0.2) !default;
+$dropdown-focus: 1px 3px rgba(color(black), 0.4), 0 1px 15px 3px rgba(color(highlight), 0.75);
 
 /**
  * Dropdown menus are useful tools for navigation, but shouldn't be used for
@@ -49,6 +50,11 @@ $dropdown-shadow-focus: 0 0 $dropdown-shadow-blur-radius 0 rgba(0, 0, 0, 0.2) !d
   cursor: pointer;
   z-index: 1; /* [4] */
   transition: all $dropdown-animation-speed ease;
+
+  &:focus {
+    box-shadow: $dropdown-focus;
+    outline: none;
+  }
 
   /**
    * The Dropdown label uses an icon to indicate when the menu has been toggled.
@@ -101,7 +107,7 @@ $dropdown-shadow-focus: 0 0 $dropdown-shadow-blur-radius 0 rgba(0, 0, 0, 0.2) !d
   list-style-type: none; /* [5] */
   background-color: $dropdown-background;
   border-radius: 0 0 $dropdown-border-radius $dropdown-border-radius; /* [3] */
-  box-shadow: $dropdown-shadow-focus;
+  box-shadow: $dropdown-shadow-active;
   opacity: 0; /* [4] */
   -ms-transform: scaleY(0); /* [5] */
   transform: scaleY(0); /* [5] */
@@ -151,13 +157,13 @@ $dropdown-shadow-focus: 0 0 $dropdown-shadow-blur-radius 0 rgba(0, 0, 0, 0.2) !d
   opacity: 0; /* [3] */
   transition: transform $dropdown-animation-speed ease, opacity $global-animation-speed-fast ease;
 
+  .c-dropdown__item:last-child & {
+    border-radius: 0 0 $dropdown-border-radius $dropdown-border-radius; /* [4] */
+  }
+
   &:hover,
   &:focus {
     background-color: $dropdown-background-focus;
-  }
-
-  &:last-child {
-    border-radius: 0 0 $dropdown-border-radius $dropdown-border-radius; /* [4] */
   }
 }
 
@@ -192,7 +198,7 @@ $dropdown-shadow-focus: 0 0 $dropdown-shadow-blur-radius 0 rgba(0, 0, 0, 0.2) !d
   */
   .c-dropdown__toggle {
     border-color: $dropdown-background;
-    box-shadow: $dropdown-shadow-focus;
+    box-shadow: $dropdown-shadow-active;
     border-radius: $dropdown-border-radius $dropdown-border-radius 0 0; /* [1] */
 
     &::after {

--- a/components/_dropdown.scss
+++ b/components/_dropdown.scss
@@ -168,7 +168,7 @@ $dropdown-focus: 1px 3px rgba(color(black), 0.4), 0 1px 15px 3px rgba(color(high
 }
 
 /**
- * Dropdown on toggle.
+ * When a dropdown's state is toggled.
  */
 .c-dropdown.is-open {
   /**


### PR DESCRIPTION
## Description
Removes checkbox hack from `c-dropdown` to a state class approach.

## Related Issue
https://github.com/sky-uk/toolkit-ui/issues/149

## Motivation and Context
It's a hack - not semantic. Using a stateful approach also allows us to make some accessibility improvements.

## Proposed Structure
Note: Could be used with button or anchor.

This will need to be updated on the Style Guide (something we need to organise going forwards)

```
<div class="c-dropdown">
  <button id="dropdown1"
          class="c-dropdown__toggle"
          aria-haspopup="true"
          aria-expanded="false">
    Dropdown Menu
  </button>
  <ul class="c-dropdown__list"
      aria-labelledby="dropdown1">
    <li class="c-dropdown__item">
      <a href="#" class="c-dropdown__link">Menu item 1</a>
    </li>
    <li class="c-dropdown__item">
      <a href="#" class="c-dropdown__link">Menu item 2</a>
    </li>
    <li class="c-dropdown__item">
      <a href="#" class="c-dropdown__link">Menu item 3</a>
    </li>
    <li class="c-dropdown__item">
      <a href="#" class="c-dropdown__link">Menu item 4</a>
    </li>
  </ul>
</div>
```

## How Has This Been Tested?
Visual and manual use checks in:
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Opera
- [x] IE9

## Types of changes
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] Changes have been browser tested (including IE).
- [x] I have added instructions on how to test my changes.
- [x] Package version updated.
- [x] CHANGELOG.md updated.
