### PR TITLE
Fix for height of square tiles being 5px greater than width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [panel] Inset shadow fix from all sides to top and bottom only.
 - [tile] Fix for `.c-tile--collapsable` with nested links breaking on mobile.
 - [tile] Fix for `.c-tile__media` height rounding down incorrectly causing a 1px gap.
+- [tile] Fix for `.c-tile--square` height 100% + 5px causing tiles such as 555px x 560px.
 - [shine] Fix for `.c-shine` when using with full width elements.
 - [select] Added `:focus` styles for accessibility.
 - [select] Fixed spacing of text.

--- a/components/_tile.scss
+++ b/components/_tile.scss
@@ -334,6 +334,7 @@ $included-tile-themes: "sky-1", "sky-account", "sky-atlantic", "sky-arts", "sky-
 .c-tile--square {
   height: 0;
   padding-top: 100%;
+  padding-bottom: 0;
 
   /**
    * Collapses square ratio at medium and sets to auto height


### PR DESCRIPTION
## Description
Currently `.c-tile--square` height is calculated with 100% tile width along with the 5px default padding-bottom causing non square tiles.

## How Has This Been Tested?
Tested locally

## Screenshots (if appropriate):

**Before:**
<img width="607" alt="screen shot 2016-09-27 at 14 27 52" src="https://cloud.githubusercontent.com/assets/2472440/18875718/ddd45414-84be-11e6-8252-4b38218e99e8.png">

**After:**
<img width="594" alt="screen shot 2016-09-27 at 14 29 28" src="https://cloud.githubusercontent.com/assets/2472440/18875727/e341dafc-84be-11e6-9caf-1d0832fda12d.png">

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] Changes have been browser tested (including IE).
- [ ] I have added instructions on how to test my changes.
- [ ] Package version updated.
- [x] CHANGELOG.md updated.
