### PR TITLE
Colors Refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Toolkit UI v1.0.0
 
 ## 1. Features
+- [colors] `ui-` prefixed colors have moved to a `grey-` prefix for greater flexibility.
 - [divider] `c-divider` for prominent horizontal (and vertical) rules for use between elements.
 - [tile] `c-tile--full` for Tiles that utilise a full size image and overlapping title.
 

--- a/components/_accordion.scss
+++ b/components/_accordion.scss
@@ -4,7 +4,7 @@
 
 $accordion-animation-speed: $global-animation-speed !default;
 $accordion-background: transparent !default;
-$accordion-border: 1px solid color(keyline) !default;
+$accordion-border: 1px solid color(grey-20) !default;
 $accordion-border-radius: $global-border-radius !default;
 $accordion-icon-size: 20px !default;
 

--- a/components/_buttons.scss
+++ b/components/_buttons.scss
@@ -143,8 +143,8 @@ $btn-animation-speed-fast: $global-animation-speed-fast !default;
   &:active,
   &:focus {
     color: color(white);
-    background-color: color(keyline);
-    border-color: color(keyline);
+    background-color: color(grey-20);
+    border-color: color(grey-20);
     cursor: not-allowed;
   }
 }

--- a/components/_dropdown.scss
+++ b/components/_dropdown.scss
@@ -6,7 +6,7 @@
 $dropdown-animation-speed: $global-animation-speed !default;
 $dropdown-background: color(white) !default;
 $dropdown-background-focus: #f4f4f4 !default;
-$dropdown-border: 1px solid color(keyline) !default;
+$dropdown-border: 1px solid color(grey-20) !default;
 $dropdown-border-radius: $global-border-radius !default;
 $dropdown-shadow-blur-radius: 8px !default;
 $dropdown-shadow: 0 0 0 0 rgba(0, 0, 0, 0.2) !default;

--- a/components/_forms.scss
+++ b/components/_forms.scss
@@ -8,7 +8,7 @@ $form-shadow-focus: 0 0 8px 0 rgba(0, 0, 0, 0.2);
 $form-shadow-error: 0 0 8px 0 rgba(color(error), 0.75);
 $form-background: color(white);
 $form-border-width: $global-border-width;
-$form-border: $form-border-width solid color(keyline);
+$form-border: $form-border-width solid color(grey-20);
 $form-font-size: text-lead-small;
 $form-checkbox-size: 1em;
 $form-checkbox-margin: $form-checkbox-size;

--- a/components/_keyline.scss
+++ b/components/_keyline.scss
@@ -15,7 +15,7 @@ $keyline-width-thick: $keyline-width * 2 !default;
 
 /* hr */.c-keyline {
   border: none;
-  border-bottom: $keyline-width solid color(keyline);
+  border-bottom: $keyline-width solid color(grey-20);
   margin-bottom: $global-spacing-unit - $keyline-width; /* [1] */
 }
 

--- a/components/_panel.scss
+++ b/components/_panel.scss
@@ -11,7 +11,7 @@ $panel-shadow-color-dark: color(black);
 $panel-shadow: $panel-shadow-size-top $panel-shadow-color, $panel-shadow-size-bottom $panel-shadow-color;
 $panel-shadow-dark: $panel-shadow-size-top $panel-shadow-color-dark, $panel-shadow-size-bottom $panel-shadow-color-dark;
 $panel-background-color: color(white) !default;
-$panel-background-color-dark: color(ui-dark) !default;
+$panel-background-color-dark: color(grey-50) !default;
 
 /**
  * 1. Break the panel outside of the current container (typically

--- a/components/_spinner.scss
+++ b/components/_spinner.scss
@@ -162,12 +162,12 @@ $spinner-transition-delay: $global-animation-speed;
  * For overlaying light-coloured UI.
  */
 .c-spinner-overlay--light {
-  background-color: color(ui-light);
+  background-color: color(grey-10);
 }
 
 /**
  * For overlaying dark-coloured UI.
  */
 .c-spinner-overlay--dark {
-  background-color: color(ui-dark);
+  background-color: color(grey-50);
 }

--- a/components/_tables.scss
+++ b/components/_tables.scss
@@ -7,7 +7,7 @@
 }
 
 .c-table-simple__row {
-  border-bottom: 1px solid color(keyline);
+  border-bottom: 1px solid color(grey-20);
 }
 
 .c-table-simple__cell {

--- a/components/_tile.scss
+++ b/components/_tile.scss
@@ -93,11 +93,11 @@ $included-tile-themes: "sky-1", "sky-account", "sky-atlantic", "sky-arts", "sky-
 
   &.c-tile--dark.is-selected {
     &::before {
-      box-shadow: 5px 5px 8px color(ui-dark); /* [4] */
+      box-shadow: 5px 5px 8px color(grey-50); /* [4] */
     }
 
     &::after {
-      background-color: color(ui-dark);
+      background-color: color(grey-50);
       box-shadow: inset $tile-arrow-size/2 $tile-arrow-size/2 $tile-arrow-size/2 (-$tile-arrow-size / 2) color(black); /* [5] */
     }
   }


### PR DESCRIPTION
Relies on https://github.com/sky-uk/toolkit-core/pull/125

## Description
Implementation of new proposed color naming in `toolkit-core`.

## Related Issue
https://github.com/sky-uk/toolkit-core/issues/100

## Motivation and Context
Current system for "grey" colours wasn't flexible, any references to these colours needed to be updated to reflect `toolkit-core`.

## How Has This Been Tested?
md5 comparison of outputted css before/after showed no change.
(without changing HEX values)
<img width="435" alt="screen shot 2016-09-28 at 11 22 01" src="https://cloud.githubusercontent.com/assets/7349341/18910047/31fa4076-856e-11e6-8d51-32cb3b1d4c3a.png">

## Types of changes
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] Changes have been browser tested (including IE).
- [x] I have added instructions on how to test my changes.
- [x] Package version updated.
- [ ] CHANGELOG.md updated.
