### PR TITLE
Checkbox / Radio Styling 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - [buttons] Added relative border to buttons so that the border width scales with font-size.
 - [buttons] Added `:focus` styles for accessibility.
 - [forms] Fix for `.c-form-checkbox` margin which broke on multi-line captions.
+- [forms] Fix for `.c-form-checkbox` error styles.
 - [forms] Fix to add border-radius and prevent text from overflowing beneath the icon on `c-form-select`.
 - [panel] Inset shadow fix from all sides to top and bottom only.
 - [tile] Fix for `.c-tile--collapsable` with nested links breaking on mobile.

--- a/components/_forms.scss
+++ b/components/_forms.scss
@@ -339,8 +339,7 @@ $form-animation-speed: $global-animation-speed-fast;
 }
 
 .c-form-checkbox__input:focus + .c-form-checkbox__caption::before {
-  border-width: 2px;
-  border-color: color(brand);
+  @include focus-styles();
 }
 
 .c-form-checkbox__input:checked + .c-form-checkbox__caption::before {
@@ -397,17 +396,20 @@ $form-animation-speed: $global-animation-speed-fast;
   =========================================== */
 
 /**
-  * Errors are handled by adding the .is-error class to the field's parent –
-  * usually the .c-form-list__item.
-  */
+ * Errors are handled by adding the .is-error class to the field's parent –
+ * usually the .c-form-list__item.
+ */
 
 .is-error {
   color: color(error);
 }
 
+/**
+ * Change form field styles
+ */
+.c-form-date,
 .c-form-input,
-.c-form-select__dropdown,
-.c-form-checkbox__faux {
+.c-form-select__dropdown {
 
   .is-error &,
   &.is-error,
@@ -419,5 +421,19 @@ $form-animation-speed: $global-animation-speed-fast;
       box-shadow: $form-shadow-error;
     }
   }
+}
 
+/**
+ * Change checkbox/radio indicator border color
+ */
+.c-form-checkbox__caption {
+
+  .is-error &,
+  &.is-error,
+  &:invalid {
+
+    &::before {
+      border-color: color(error);
+    }
+  }
 }


### PR DESCRIPTION
## Description
Provides error styling for checkbox and radio indicator borders

## Related Issue
https://github.com/sky-uk/toolkit-ui/issues/33

## How Has This Been Tested?
Visually in all browsers

## Screenshots (if appropriate)
<img width="384" alt="screen shot 2016-10-03 at 15 03 49" src="https://cloud.githubusercontent.com/assets/7349341/19040123/b9361aaa-897a-11e6-9767-dbb1d79fa241.png">

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Browser Support
- [x] Chrome
- [x] Edge
- [x] Firefox
- [x] IE9
- [x] IE10
- [x] IE11
- [x] Opera
- [x] Safari
- [x] Mobile Devices

## Checklist
- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] I have added instructions on how to test my changes.
- [x] Package version updated.
- [x] CHANGELOG.md updated.
