### PR TITLE
Refactor / Panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ## 4. Refactor
 - [dropdown] No longer utilises a checkbox hack, improving semantic structure and accessibility. Now implements a stateful `.is-open` class.
-- [panel] Panel fits to content by default, with full viewport height achieved with the `c-panel--full` modifier.
+- [panel] Panel fits to content by default, with full viewport height achieved with the `c-panel--constrain` modifier.
 
 ## 5. Bug Fixes
 - [accordion] Fixed arrow icon alignment in IE9.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ## 4. Refactor
 - [dropdown] No longer utilises a checkbox hack, improving semantic structure and accessibility. Now implements a stateful `.is-open` class.
+- [panel] Panel fits to content by default, with full viewport height achieved with the `c-panel--full` modifier.
 
 ## 5. Bug Fixes
 - [accordion] Fixed arrow icon alignment in IE9.

--- a/components/_panel.scss
+++ b/components/_panel.scss
@@ -51,10 +51,10 @@ $panel-background-color-dark: color(grey-50) !default;
 }
 
 /**
- * Full panels stretch to the full viewport height when open.
+ * Constrain panels restrict content to full viewport height when open.
  */
 
-.c-panel--full {
+.c-panel--constrain {
   &.is-open {
     max-height: 100vh;
   }

--- a/components/_panel.scss
+++ b/components/_panel.scss
@@ -30,7 +30,7 @@ $panel-background-color-dark: color(grey-50) !default;
   max-height: 0;
 
   &.is-open {
-    max-height: auto;
+    max-height: none;
     margin-bottom: $global-spacing-unit;
   }
 }

--- a/components/_panel.scss
+++ b/components/_panel.scss
@@ -30,7 +30,7 @@ $panel-background-color-dark: color(grey-50) !default;
   max-height: 0;
 
   &.is-open {
-    max-height: 100vh;
+    max-height: auto;
     margin-bottom: $global-spacing-unit;
   }
 }
@@ -40,12 +40,9 @@ $panel-background-color-dark: color(grey-50) !default;
   padding-bottom: $global-spacing-unit;
 }
 
-/* Darker panels
-  =========================================== */
-
 /**
-  * 1. Darker panels have no shadow/gradient
-  */
+ * Dark panels
+ */
 
 .c-panel--dark {
   background-color: $panel-background-color-dark;
@@ -53,14 +50,24 @@ $panel-background-color-dark: color(grey-50) !default;
   color: color(white);
 }
 
+/**
+ * Full panels stretch to the full viewport height when open.
+ */
+
+.c-panel--full {
+  &.is-open {
+    max-height: 100vh;
+  }
+}
+
 /* Toggle links
   =========================================== */
 
 /**
-  * Close button for panels
-  * 1. Position the button in top right of panel
-  * 2. Offset cross icon to align with text
-  */
+ * Close button for panels
+ * 1. Position the button in top right of panel
+ * 2. Offset cross icon to align with text
+ */
 
 .c-panel__toggle {
   @include font-size(text-lead-small);


### PR DESCRIPTION
## Description
Panels now default to no max-height, with `c-panel--full` to achieve the previous `100vh` effect.

## Related Issue
https://github.com/sky-uk/toolkit-ui/issues/109

## Motivation and Context
The current method is restrictive and prevents content flow.

## Types of Changes
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Browser Support
- [x] Chrome
- [x] Edge
- [x] Firefox
- [x] IE9
- [x] IE10
- [x] IE11
- [x] Opera
- [x] Safari
- [x] Mobile Devices

## Checklist
- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] I have added instructions on how to test my changes.
- [x] CHANGELOG.md updated.
