### PR TITLE
Fix shine background position

### DIFF
--- a/components/_shine.scss
+++ b/components/_shine.scss
@@ -76,8 +76,8 @@ $shine-offset: 25%;
    * Shine Diffaction Spike
    */
   &::before {
-    background: -webkit-radial-gradient(rgba(white, 0.8) 15%, rgba(white, 0.15) 38%, rgba(white, 0) 50%);
-    background: radial-gradient(rgba(white, 0.8) 15%, rgba(white, 0.15) 38%, rgba(white, 0) 50%);
+    background-image: -webkit-radial-gradient(rgba(white, 0.8) 15%, rgba-image(white, 0.15) 38%, rgba(white, 0) 50%);
+    background-image: radial-gradient(rgba(white, 0.8) 15%, rgba(white, 0.15) 38%, rgba(white, 0) 50%);
     background-size: 15em 0.8em;
   }
 
@@ -85,8 +85,8 @@ $shine-offset: 25%;
    * Shine Orb
    */
   &::after {
-    background: -webkit-radial-gradient(rgba(white, 0.8) 15%, rgba(white, 0.25) 35%, rgba(white, 0.15) 40%, rgba(white, 0) 50%);
-    background: radial-gradient(rgba(white, 0.8) 15%, rgba(white, 0.25) 35%, rgba(white, 0.15) 40%, rgba(white, 0) 50%);
+    background-image: -webkit-radial-gradient(rgba(white, 0.8) 15%, rgba(white, 0.25) 35%, rgba(white, 0.15) 40%, rgba(white, 0) 50%);
+    background-image: radial-gradient(rgba(white, 0.8) 15%, rgba(white, 0.25) 35%, rgba(white, 0.15) 40%, rgba(white, 0) 50%);
     background-size: 3em 1.4em;
   }
 


### PR DESCRIPTION
## Description
New shine uses `background` not `background-image` which leads to position being overwritten

## Related Issue
N/A

## Motivation and Context
Breaks the positioning of the shine.

## How Has This Been Tested?
Visually checked in all browsers

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Browser Support
- [x] Chrome
- [x] Edge
- [x] Firefox
- [x] IE9
- [x] IE10
- [x] IE11
- [x] Opera
- [x] Safari
- [x] Mobile Devices

## Checklist
- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] I have added instructions on how to test my changes.
- [ ] CHANGELOG.md updated. (N/A Fixes bug in pre-release feature)

