### PR TITLE
[Feature] Inline Checkbox/Radio inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@
 ## 2. Features
 - [colors] `ui-` prefixed colors have moved to a `grey-` prefix for greater flexibility.
 - [divider] `c-divider` for prominent horizontal (and vertical) rules for use between elements.
+- [forms] `c-form-checkbox--inline` for inline checkbox/radio inputs.
 - [tile] `c-tile--full` for Tiles that utilise a full size image and overlapping title.
 - [tile] Extra test for generating themed tiles.
-
 
 ## 3. Deprecations
 - [legacy-typography] Config switch now fully deprecated.

--- a/components/_forms.scss
+++ b/components/_forms.scss
@@ -310,6 +310,18 @@ $form-animation-speed: $global-animation-speed-fast;
   cursor: pointer;
 }
 
+/**
+ * For cases where checkboxes or radio buttons need to display inline.
+ */
+.c-form-checkbox--inline {
+  width: auto;
+  margin-right: $global-spacing-unit-large;
+}
+
+/**
+ * Hide the default input visually to utilise keyboard functionality and allow
+ * for custom input styles.
+ */
 .c-form-checkbox__input {
   @include hide-visually();
 }


### PR DESCRIPTION
# Description
By default checkboxes/radio buttons should be stacked, but we should also provide inline styles for shorter captions.

## Related Issue
https://github.com/sky-uk/toolkit-ui/issues/179

## Screenshots (if appropriate)
![screen shot 2016-10-24 at 16 11 13](https://cloud.githubusercontent.com/assets/7349341/19651629/8c774386-9a05-11e6-9781-e6c2edbe6e03.png)

## Types of Changes
- [x] New feature (non-breaking change which adds functionality)

## Browser Support
- [x] Chrome
- [x] Edge
- [x] Firefox
- [x] IE9
- [x] IE10
- [x] IE11
- [x] Opera
- [x] Safari
- [x] Mobile Devices

## Checklist
- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] I have added instructions on how to test my changes.
- [x] CHANGELOG.md updated.

cc @StefanMcCready @liamhutchinson 