### PR TITLE
[Patch] Shine sizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Toolkit UI v1.0.2
+
+## 1. Bug Fixes
+- [shine] Repair background-sizing for shine patch in `1.0.1`.
+
+===
+
 # Toolkit UI v1.0.1
 
 ## 1. Bug Fixes

--- a/components/_shine.scss
+++ b/components/_shine.scss
@@ -78,7 +78,7 @@ $shine-offset: 25%;
   &::before {
     background-image: -webkit-radial-gradient(rgba(white, 0.8) 15%, rgba-image(white, 0.15) 38%, rgba(white, 0) 50%);
     background-image: radial-gradient(rgba(white, 0.8) 15%, rgba(white, 0.15) 38%, rgba(white, 0) 50%);
-    background-size: 15em 0.8em;
+    background-size: 300px 16px;
   }
 
   /**
@@ -87,7 +87,7 @@ $shine-offset: 25%;
   &::after {
     background-image: -webkit-radial-gradient(rgba(white, 0.8) 15%, rgba(white, 0.25) 35%, rgba(white, 0.15) 40%, rgba(white, 0) 50%);
     background-image: radial-gradient(rgba(white, 0.8) 15%, rgba(white, 0.25) 35%, rgba(white, 0.15) 40%, rgba(white, 0) 50%);
-    background-size: 3em 1.4em;
+    background-size: 60px 28px;
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sky-toolkit-ui",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "The UI layer of Sky's CSS Toolkit",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Description
`1.0.1` missed a crucial change to background-size - leading to awkward sizing on some smaller tiles on Sky Pages.

e.g.
![screen shot 2016-11-03 at 14 51 58](https://cloud.githubusercontent.com/assets/7349341/19970841/1d4db666-a1d5-11e6-9cab-422f7b7266c0.png)

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
## Browser Support
- [x] Chrome
- [x] Edge
- [x] Firefox
- [x] IE9
- [x] IE10
- [x] IE11
- [x] Opera
- [x] Safari
- [x] Mobile Devices

## Checklist
- [ ] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] I have added instructions on how to test my changes.
- [x] Package version updated.
- [x] CHANGELOG.md updated.

