### PR TITLE
Updated tile to use new panel indicator mixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Toolkit UI v1.1.0
+
+## 1. Features
+- [tile] makes use of `panel-indicator` mixin for `is-selected`.
+
+===
+
 # Toolkit UI v1.0.2
 
 ## 1. Bug Fixes

--- a/components/_tile.scss
+++ b/components/_tile.scss
@@ -54,52 +54,11 @@ $included-tile-themes: "sky-1", "sky-account", "sky-atlantic", "sky-arts", "sky-
   }
 
   &.is-selected {
-    /**
-     * Arrow markers to signify panel relationship.
-     *
-     * 1. Positions the marker between tile and panel
-     * 2. Need to take off an extra pixel here to allow for browser rendering/
-     *    rounding quirks.
-     * 3. Rotate 45deg to allow it to mask the panel gradient and look like a
-     *    notch in the panel (webkit placed after to prevent render quirk)
-     * 4. Box-shadow that matches the panel background color to smooth the
-     *    shadow transition
-     * 5. Inset box-shadow that is offset to be visible only on the top edges
-     */
-    &::before,
-    &::after {
-      display: block;
-      content: "";
-      position: absolute;  /* [1] */
-      bottom: -$global-spacing-unit - ($tile-arrow-size/2) - 1px; /* [1, 2] */
-      left: 50%;  /* [1] */
-      width: $tile-arrow-size;
-      height: $tile-arrow-size;
-      margin-left: -$tile-arrow-size/2; /* [1] */
-      -ms-transform: rotate(45deg); /* [3] */
-      transform: rotate(45deg); /* [3] */
-      -webkit-transform: translate3d(0, 0, 0) rotate(45deg); /* [3] */
-    }
-
-    &::before {
-      box-shadow: 5px 5px 8px $tile-arrow-color; /* [4] */
-    }
-
-    &::after {
-      background-color: $tile-arrow-color;
-      box-shadow: inset $tile-arrow-size/2 $tile-arrow-size/2 $tile-arrow-size/2 (-$tile-arrow-size / 2) #9f9f9f; /* [5] */
-    }
+    @include panel-indicator();
   }
 
   &.c-tile--dark.is-selected {
-    &::before {
-      box-shadow: 5px 5px 8px color(grey-50); /* [4] */
-    }
-
-    &::after {
-      background-color: color(grey-50);
-      box-shadow: inset $tile-arrow-size/2 $tile-arrow-size/2 $tile-arrow-size/2 (-$tile-arrow-size / 2) color(black); /* [5] */
-    }
+    @include panel-indicator("dark");
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sky-toolkit-ui",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "The UI layer of Sky's CSS Toolkit",
   "main": "index.js",
   "scripts": {
@@ -24,6 +24,6 @@
   },
   "homepage": "https://github.com/sky-uk/toolkit-ui#readme",
   "dependencies": {
-    "sky-toolkit-core": "1.0.0"
+    "sky-toolkit-core": "1.1.0"
   }
 }


### PR DESCRIPTION
## Description
Refactored to use panel-indicator mixin. See https://github.com/sky-uk/toolkit-core/pull/150

## Related Issue
https://github.com/sky-uk/toolkit-ui/issues/114

https://github.com/sky-uk/toolkit-core/pull/150

## Motivation and Context
This allows people to easily use panel indicator on non-tile elements.

## How Has This Been Tested?
Tested locally

## Screenshots (if appropriate)

## Types of Changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Browser Support
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] IE9
- [ ] IE10
- [ ] IE11
- [ ] Opera
- [x] Safari
- [ ] Mobile Devices

## Checklist
- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [ ] I have added instructions on how to test my changes.
- [x] Package version updated.
- [x] CHANGELOG.md updated.