### PR TITLE
[Enhancement] z-index map

### DIFF
--- a/components/_calendar.scss
+++ b/components/_calendar.scss
@@ -65,7 +65,7 @@ $calendar-navigation-modifiers: (
   width: $calendar-nav-width;
   height: 30px;
   padding: 0;
-  z-index: 1;
+  z-index: z-index(over-content);
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;

--- a/components/_dropdown.scss
+++ b/components/_dropdown.scss
@@ -5,13 +5,11 @@
 // Dropdown settings
 $dropdown-animation-speed: $global-animation-speed !default;
 $dropdown-background: color(white) !default;
-$dropdown-background-focus: #f4f4f4 !default;
+$dropdown-background-focus: color(grey-10) !default;
 $dropdown-border: 1px solid color(grey-20) !default;
 $dropdown-border-radius: $global-border-radius !default;
-$dropdown-shadow-blur-radius: 8px !default;
-$dropdown-shadow: 0 0 0 0 rgba(0, 0, 0, 0.2) !default;
-$dropdown-shadow-active: 0 0 $dropdown-shadow-blur-radius 0 rgba(0, 0, 0, 0.2) !default;
-$dropdown-focus: 1px 3px rgba(color(black), 0.4), 0 1px 15px 3px rgba(color(highlight), 0.75);
+$dropdown-shadow: 0 0 0 0 rgba(color(black), 0.2) !default;
+$dropdown-shadow-active: 0 0 8px 0 rgba(color(black), 0.2) !default;
 
 /**
  * Dropdown menus are useful tools for navigation, but shouldn't be used for
@@ -52,8 +50,7 @@ $dropdown-focus: 1px 3px rgba(color(black), 0.4), 0 1px 15px 3px rgba(color(high
   transition: border $dropdown-animation-speed ease, border-radius $dropdown-animation-speed ease, box-shadow $dropdown-animation-speed ease;
 
   &:focus {
-    box-shadow: $dropdown-focus;
-    outline: none;
+    @include focus-styles();
   }
 
   /**

--- a/components/_dropdown.scss
+++ b/components/_dropdown.scss
@@ -48,7 +48,7 @@ $dropdown-focus: 1px 3px rgba(color(black), 0.4), 0 1px 15px 3px rgba(color(high
   background-color: $dropdown-background;
   outline: 0;
   cursor: pointer;
-  z-index: 1; /* [4] */
+  z-index: z-index(content); /* [4] */
   transition: border $dropdown-animation-speed ease, border-radius $dropdown-animation-speed ease, box-shadow $dropdown-animation-speed ease;
 
   &:focus {
@@ -103,7 +103,7 @@ $dropdown-focus: 1px 3px rgba(color(black), 0.4), 0 1px 15px 3px rgba(color(high
   width: 100%;
   position: absolute;
   margin: 0; /* [1] */
-  z-index: 2; /* [2] */
+  z-index: z-index(over-control); /* [2] */
   list-style-type: none; /* [5] */
   background-color: $dropdown-background;
   border-radius: 0 0 $dropdown-border-radius $dropdown-border-radius; /* [3] */

--- a/components/_dropdown.scss
+++ b/components/_dropdown.scss
@@ -1,5 +1,5 @@
 /* ==========================================================================
-   COMPONENTS / DROPDOWN
+   COMPONENTS / #DROPDOWN
    ========================================================================== */
 
 // Dropdown settings
@@ -11,7 +11,12 @@ $dropdown-border-radius: $global-border-radius !default;
 $dropdown-shadow: 0 0 0 0 rgba(color(black), 0.2) !default;
 $dropdown-shadow-active: 0 0 8px 0 rgba(color(black), 0.2) !default;
 
+/* Base
+  =========================================== */
+
 /**
+ * Dropdown
+ *
  * Dropdown menus are useful tools for navigation, but shouldn't be used for
  * form input purposes (see `c-form-select` for form use).
  *
@@ -24,7 +29,9 @@ $dropdown-shadow-active: 0 0 8px 0 rgba(color(black), 0.2) !default;
 }
 
 /**
- * The Dropdown label provides context to the menu and acts as an input to
+ * Dropdown Toggle
+ *
+ * Provides context to the menu and acts as an input to
  * toggle the item list.
  *
  * 1. Set font-size and line-height
@@ -54,7 +61,9 @@ $dropdown-shadow-active: 0 0 8px 0 rgba(color(black), 0.2) !default;
   }
 
   /**
-   * The Dropdown label uses an icon to indicate when the menu has been toggled.
+   * Dropdown Indicator
+   *
+   * The Dropdown Toggle uses an icon to indicate when the menu has been toggled.
    * N.B. Temporary use of Base64 until a Sky SVG solution is realised.
    *
    * 3. Allows for positioning from the top and right of the dropdown.
@@ -84,7 +93,9 @@ $dropdown-shadow-active: 0 0 8px 0 rgba(color(black), 0.2) !default;
 }
 
 /**
- * The Dropdown list contains menu items, appearing when the label is toggled.
+ * Dropdown List
+ *
+ * Contains menu items, appearing when the label is toggled.
  *
  * 1. Removes default list margins.
  * 2. Sets the list to be stacked above the the label.
@@ -114,7 +125,9 @@ $dropdown-shadow-active: 0 0 8px 0 rgba(color(black), 0.2) !default;
   transition: all $dropdown-animation-speed ease; /* [13] */
 
   /**
-   * As the Dropdown label and Dropdown list use similar box-shadows, there will
+   * Dropdown Shadow Overlap
+   *
+   * As the Dropdown toggle and Dropdown list use similar box-shadows, there will
    * inevitably be overlap. To prevent this overlap, the Dropdown list uses a
    * pseudo-element with a matching background-color to cover the shadow.
    *
@@ -133,8 +146,9 @@ $dropdown-shadow-active: 0 0 8px 0 rgba(color(black), 0.2) !default;
 }
 
 /**
- * The Dropdown link class provides styling for individual menu items within the
- * Dropdown list.
+ * Dropdown Link
+ *
+ * Provides styling for individual menu items within the Dropdown list.
  *
  * 1. Overides default link color.
  * 2. As we use scaleY on the Dropdown list to toggle the menu, each item is
@@ -164,13 +178,11 @@ $dropdown-shadow-active: 0 0 8px 0 rgba(color(black), 0.2) !default;
   }
 }
 
-/**
- * When a dropdown's state is toggled.
- */
+/* States
+  =========================================== */
+
 .c-dropdown.is-open {
   /**
-   * Dropdown list on toggle.
-   *
    * 1. Scales vertical axis to its full height to achieve 'slide' animation.
    * 2. Sets text to its correct height to animate upon.
   */
@@ -188,8 +200,6 @@ $dropdown-shadow-active: 0 0 8px 0 rgba(color(black), 0.2) !default;
   }
 
   /**
-   * Dropdown label on toggle.
-   *
    * 1. Removes border-radius on bottom edge to overlap the dropdown list.
    * 2. Rotates icon indicator 180 degrees.
   */
@@ -205,8 +215,8 @@ $dropdown-shadow-active: 0 0 8px 0 rgba(color(black), 0.2) !default;
   }
 }
 
-/* Dropdown sizing modifiers
-   =========================================== */
+/* Modifiers
+  =========================================== */
 
 /**
 * For dropdowns that need to display full-width.

--- a/components/_dropdown.scss
+++ b/components/_dropdown.scss
@@ -48,7 +48,7 @@ $dropdown-focus: 1px 3px rgba(color(black), 0.4), 0 1px 15px 3px rgba(color(high
   background-color: $dropdown-background;
   outline: 0;
   cursor: pointer;
-  z-index: z-index(content); /* [4] */
+  z-index: 1; /* [4] */
   transition: border $dropdown-animation-speed ease, border-radius $dropdown-animation-speed ease, box-shadow $dropdown-animation-speed ease;
 
   &:focus {
@@ -103,7 +103,7 @@ $dropdown-focus: 1px 3px rgba(color(black), 0.4), 0 1px 15px 3px rgba(color(high
   width: 100%;
   position: absolute;
   margin: 0; /* [1] */
-  z-index: z-index(over-control); /* [2] */
+  z-index: 2; /* [2] */
   list-style-type: none; /* [5] */
   background-color: $dropdown-background;
   border-radius: 0 0 $dropdown-border-radius $dropdown-border-radius; /* [3] */

--- a/components/_dropdown.scss
+++ b/components/_dropdown.scss
@@ -48,7 +48,7 @@ $dropdown-focus: 1px 3px rgba(color(black), 0.4), 0 1px 15px 3px rgba(color(high
   background-color: $dropdown-background;
   outline: 0;
   cursor: pointer;
-  z-index: 1; /* [4] */
+  z-index: z-index(over-content); /* [4] */
   transition: border $dropdown-animation-speed ease, border-radius $dropdown-animation-speed ease, box-shadow $dropdown-animation-speed ease;
 
   &:focus {
@@ -103,7 +103,7 @@ $dropdown-focus: 1px 3px rgba(color(black), 0.4), 0 1px 15px 3px rgba(color(high
   width: 100%;
   position: absolute;
   margin: 0; /* [1] */
-  z-index: 2; /* [2] */
+  z-index: z-index(over-control); /* [2] */
   list-style-type: none; /* [5] */
   background-color: $dropdown-background;
   border-radius: 0 0 $dropdown-border-radius $dropdown-border-radius; /* [3] */

--- a/components/_dropdown.scss
+++ b/components/_dropdown.scss
@@ -185,7 +185,7 @@ $dropdown-shadow-active: 0 0 8px 0 rgba(color(black), 0.2) !default;
   /**
    * 1. Scales vertical axis to its full height to achieve 'slide' animation.
    * 2. Sets text to its correct height to animate upon.
-  */
+   */
   .c-dropdown__list {
     opacity: 1;
     -ms-transform: scaleY(1); /* [1] */
@@ -202,7 +202,7 @@ $dropdown-shadow-active: 0 0 8px 0 rgba(color(black), 0.2) !default;
   /**
    * 1. Removes border-radius on bottom edge to overlap the dropdown list.
    * 2. Rotates icon indicator 180 degrees.
-  */
+   */
   .c-dropdown__toggle {
     border-color: $dropdown-background;
     box-shadow: $dropdown-shadow-active;
@@ -219,16 +219,16 @@ $dropdown-shadow-active: 0 0 8px 0 rgba(color(black), 0.2) !default;
   =========================================== */
 
 /**
-* For dropdowns that need to display full-width.
-*/
+ * For dropdowns that need to display full-width.
+ */
 .c-dropdown--full {
   display: block;
   width: 100%;
 }
 
 /**
-* For dropdowns that need to display full-width on small devices only.
-*/
+ * For dropdowns that need to display full-width on small devices only.
+ */
 .c-dropdown--full\@small-only {
   @include mq($until: medium) {
     display: block;

--- a/components/_shine.scss
+++ b/components/_shine.scss
@@ -16,7 +16,7 @@ $shine-offset: 25%;
   height: $shine-size;
   width: 100%;
   transition: $global-animation-speed ease-out;
-  z-index: 1000;
+  z-index: z-index(over-everything);
 }
 
 /**

--- a/components/_spinner.scss
+++ b/components/_spinner.scss
@@ -21,7 +21,7 @@ $spinner-transition-delay: $global-animation-speed;
   width: 1em; /* [1] */
   height: 1em; /* [1] */
   font-size: $spinner-size; /* [1] */
-  color: #0072c9; /* [2] */
+  color: color(brand); /* [2] */
   border: 0.08em solid; /* [3] */
   border-color: transparent currentColor currentColor; /* [2][4] */
   vertical-align: middle;
@@ -102,7 +102,7 @@ $spinner-transition-delay: $global-animation-speed;
   left: 0; /* [1] */
   opacity: 1; /* [2] */
   visibility: visible; /* [2] */
-  z-index: 1000; /* [3] */
+  z-index: z-index(over-screen); /* [3] */
   transition: opacity $spinner-animation-speed ease, visibility $spinner-animation-speed ease; /* [4] */
 
   /**

--- a/components/_tile.scss
+++ b/components/_tile.scss
@@ -47,7 +47,7 @@ $included-tile-themes: "sky-1", "sky-account", "sky-atlantic", "sky-arts", "sky-
   padding: $tile-border-width;
   margin-bottom: $global-spacing-unit;
   will-change: transform;
-  z-index: 10; /* [1] */
+  z-index: z-index(over-content); /* [1] */
 
   &.has-focus {
     @include focus-styles();
@@ -175,7 +175,7 @@ $included-tile-themes: "sky-1", "sky-account", "sky-atlantic", "sky-arts", "sky-
    */
   .c-tile--full & {
     height: auto;
-    z-index: 10;
+    z-index: z-index(over-content);
     position: relative;
   }
 }
@@ -208,7 +208,7 @@ $included-tile-themes: "sky-1", "sky-account", "sky-atlantic", "sky-arts", "sky-
 .c-tile__caption {
   position: relative;
   height: 45%;
-  z-index: 20;
+  z-index: z-index(over-control);
 
   /**
    * Sets height to auto below medium on collapsable tiles
@@ -231,7 +231,7 @@ $included-tile-themes: "sky-1", "sky-account", "sky-atlantic", "sky-arts", "sky-
   left: 1em;
   right: 1em;
   height: 20%;
-  z-index: 20;
+  z-index: z-index(over-control);
 
   &--large {
     height: 25%;
@@ -340,13 +340,13 @@ $included-tile-themes: "sky-1", "sky-account", "sky-atlantic", "sky-arts", "sky-
   }
 
   &::before {
-    z-index: -2; // Set below caption to avoid hiding content
+    z-index: z-index(under-control); // Set below caption to avoid hiding content
   }
 
   .c-tile__link &::after {
     opacity: 0; // Set initial opacity
     transition: opacity $tile-animation-speed ease;
-    z-index: -1; // Set between before and content.
+    z-index: z-index(under-content); // Set between before and content.
   }
 
   .c-tile__link:hover &::after {
@@ -395,7 +395,7 @@ $included-tile-themes: "sky-1", "sky-account", "sky-atlantic", "sky-arts", "sky-
   position: absolute;
   right: 0;
   left: 0;
-  z-index: 1;
+  z-index: z-index(content);
 }
 
 .c-tile__shine--top {

--- a/components/_tooltip.scss
+++ b/components/_tooltip.scss
@@ -5,7 +5,6 @@
 // Settings
 $tooltip-width: 20em;
 $tooltip-marker-size: 10px;
-$tooltip-z-base: 50;
 
 /**
  * Tooltip wrapper to contain content and trigger. Uses `before` pseudo for bubble
@@ -28,7 +27,7 @@ $tooltip-z-base: 50;
     content: "";
     display: inline-block;
     position: absolute;
-    z-index: $tooltip-z-base+3; /* [1] */
+    z-index: z-index(over-screen); /* [1] */
     top: 100%; /* [2] */
     left: 50%; /* [2] */
     margin-left: -($tooltip-marker-size/2); /* [2] */
@@ -48,7 +47,7 @@ $tooltip-z-base: 50;
     position: fixed;
     top: 0;
     left: 0;
-    z-index: $tooltip-z-base+1; /* [6] */
+    z-index: z-index(over-control); /* [6] */
     height: 100%;
     width: 100%;
     background-color: rgba(color(white), 0.85);
@@ -67,7 +66,7 @@ $tooltip-z-base: 50;
   .is-active &,
   .c-tooltip--hover:hover & {
     position: relative;
-    z-index: $tooltip-z-base+2; /* [1] */
+    z-index: z-index(over-page); /* [1] */
   }
 }
 
@@ -92,7 +91,7 @@ $tooltip-z-base: 50;
     @include font-size(text-body-small);
     display: block;
     position: absolute;
-    z-index: $tooltip-z-base+2; /* [1] */
+    z-index: z-index(over-page); /* [1] */
     top: 100%; /* [2] */
     left: 0; /* [2] */
     padding: $global-spacing-unit-small;


### PR DESCRIPTION
**Dependent on https://github.com/sky-uk/toolkit-core/pull/157**

---

## Description
- Utilisation of `$z-index` map from toolkit-core.
- Tidy up Dropdown documentation and fix focus styles.

## Related Issue
https://github.com/sky-uk/toolkit-core/issues/53
https://github.com/sky-uk/toolkit-ui/pull/194

## Motivation and Context
Current z-index situation is messy, difficult to track and difficult to update. A map will help improve consistency and efficiency.

## How Has This Been Tested?
Current tests pass in toolkit-core, and a new test have been created to support the new `z-index()` function.

## Screenshots (if appropriate)
N/A

## Types of Changes
- [x] New feature (non-breaking change which adds functionality)

## Browser Support
- [x] Chrome
- [x] Edge
- [x] Firefox
- [x] IE9
- [x] IE10
- [x] IE11
- [x] Opera
- [x] Safari
- [x] Mobile Devices
- [x] Screen-readers (e.g. JAWS, Apple VoiceOver)

## Checklist
- [x] All code includes full inline documentation (as per the [template](https://github.com/sky-uk/toolkit-core/blob/master/_template.scss)).
- [x] All code conforms to the Toolkit [coding style](https://github.com/sky-uk/toolkit/wiki/Coding-Style).
- [x] All code conforms to [WCAG 2.0 level AA Accessibility Guidelines](https://www.w3.org/TR/WCAG20/).
- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] I have added instructions on how to test my changes.
- [ ] Package version updated.
- [ ] CHANGELOG.md updated.
