### PR TITLE
Assign $tile-fluid-base-breakpoint as !default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ===
 
+# Toolkit UI v1.2.1
+
+## 1. Fixes
+- [tile-fluid] Set `$tile-fluid-base-breakpoint` as `!default` to allow overwriting.
+
+======
+
 # Toolkit UI v1.2.0
 
 ## 1. Dependencies

--- a/components/_tile-fluid.scss
+++ b/components/_tile-fluid.scss
@@ -19,7 +19,7 @@
  *
  */
 
-$tile-fluid-base-breakpoint: map-get($mq-breakpoints, small);
+$tile-fluid-base-breakpoint: map-get($mq-breakpoints, small) !default;
 
 /* Tile Fluid base font size
  * ==============================================

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sky-toolkit-ui",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "The UI layer of Sky's CSS Toolkit",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Description
`$tile-fluid-base-breakpoint` is currently hardcoded meaning we can't specify a different value which is essential to integrate with Sky Pages.

## Related Issue
n/a

## Motivation and Context
* Fixes an integration issue with Sky Pages
* Allows customisation of base breakpoint values

## How Has This Been Tested?
Tested locally

## Screenshots (if appropriate)
n/a

## Types of Changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Browser Support
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] IE9
- [ ] IE10
- [ ] IE11
- [ ] Opera
- [ ] Safari
- [ ] Mobile Devices
- [ ] Screen-readers (e.g. JAWS, Apple VoiceOver)

## Checklist
- [x] All code includes full inline documentation (as per the [template](https://github.com/sky-uk/toolkit-core/blob/master/_template.scss)).
- [x] All code conforms to the Toolkit [coding style](https://github.com/sky-uk/toolkit/wiki/Coding-Style).
- [x] All code conforms to [WCAG 2.0 level AA Accessibility Guidelines](https://www.w3.org/TR/WCAG20/).
- [ ] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [ ] I have added instructions on how to test my changes.
- [x] Package version updated.
- [x] CHANGELOG.md updated.