### PR TITLE
fix width of the dropdown with the className 'c-dropdown--full'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@ node_modules/
 npm-debug.log
 .DS_Store
 build/
-.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 npm-debug.log
 .DS_Store
 build/
+.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [toolkit-core](https://github.com/sky-uk/toolkit-core) updated to `1.4.0`.
 
 ## 2. Fixes
+- [dropdown] Fix for full-width dropdowns.
 - [tile] Prevent IE9 adding height attributes for asynchronously rendered images.
 - [tooltip] Fix for mobile appearance. Fix for `c-tooltip--right` on hover.
 

--- a/components/_dropdown.scss
+++ b/components/_dropdown.scss
@@ -46,8 +46,9 @@ $dropdown-focus: 1px 3px rgba(color(black), 0.4), 0 1px 15px 3px rgba(color(high
   @include font-size(text-lead-small); /* [1] */
   display: block; /* [2] */
   position: relative;
-  font-weight: bold;
   padding: $global-spacing-unit-tiny/2 $global-spacing-unit-large $global-spacing-unit-tiny/2 $global-spacing-unit-small; /* [3] */
+  font-weight: bold;
+  text-align: left;
   border: $dropdown-border;
   border-radius: $dropdown-border-radius;
   color: color(text);
@@ -55,7 +56,6 @@ $dropdown-focus: 1px 3px rgba(color(black), 0.4), 0 1px 15px 3px rgba(color(high
   outline: 0;
   cursor: pointer;
   z-index: 1; /* [4] */
-  text-align: left;
   transition: border $dropdown-animation-speed ease, border-radius $dropdown-animation-speed ease, box-shadow $dropdown-animation-speed ease;
 
   &:focus {
@@ -200,9 +200,9 @@ $dropdown-focus: 1px 3px rgba(color(black), 0.4), 0 1px 15px 3px rgba(color(high
   }
 
   .c-dropdown__link {
+    opacity: 1;
     -ms-transform: scaleY(1); /* [2] */
     transform: scaleY(1); /* [2] */
-    opacity: 1;
   }
 
   /**

--- a/components/_dropdown.scss
+++ b/components/_dropdown.scss
@@ -9,9 +9,7 @@ $dropdown-background-focus: #f4f4f4 !default;
 $dropdown-border: 1px solid color(grey-20) !default;
 $dropdown-border-radius: $global-border-radius !default;
 $dropdown-shadow-blur-radius: 8px !default;
-$dropdown-shadow: 0 0 0 0 rgba(0, 0, 0, 0.2) !default;
 $dropdown-shadow-active: 0 0 $dropdown-shadow-blur-radius 0 rgba(0, 0, 0, 0.2) !default;
-$dropdown-focus: 1px 3px rgba(color(black), 0.4), 0 1px 15px 3px rgba(color(highlight), 0.75);
 
 /* Base
   =========================================== */
@@ -59,8 +57,7 @@ $dropdown-focus: 1px 3px rgba(color(black), 0.4), 0 1px 15px 3px rgba(color(high
   transition: border $dropdown-animation-speed ease, border-radius $dropdown-animation-speed ease, box-shadow $dropdown-animation-speed ease;
 
   &:focus {
-    box-shadow: $dropdown-focus;
-    outline: none;
+    @include focus-styles();
   }
 
   /**

--- a/components/_dropdown.scss
+++ b/components/_dropdown.scss
@@ -217,6 +217,9 @@ $dropdown-focus: 1px 3px rgba(color(black), 0.4), 0 1px 15px 3px rgba(color(high
 .c-dropdown--full {
   display: block;
   width: 100%;
+  .c-dropdown__toggle {
+    width: 100%;
+  }
 }
 
 /**
@@ -226,5 +229,8 @@ $dropdown-focus: 1px 3px rgba(color(black), 0.4), 0 1px 15px 3px rgba(color(high
   @include mq($until: medium) {
     display: block;
     width: 100%;
+    .c-dropdown__toggle {
+      width: 100%;
+    }
   }
 }

--- a/components/_dropdown.scss
+++ b/components/_dropdown.scss
@@ -2,7 +2,7 @@
    COMPONENTS / #DROPDOWN
    ========================================================================== */
 
-// Dropdown settings
+// Dropdown Settings
 $dropdown-animation-speed: $global-animation-speed !default;
 $dropdown-background: color(white) !default;
 $dropdown-background-focus: #f4f4f4 !default;
@@ -13,7 +13,12 @@ $dropdown-shadow: 0 0 0 0 rgba(0, 0, 0, 0.2) !default;
 $dropdown-shadow-active: 0 0 $dropdown-shadow-blur-radius 0 rgba(0, 0, 0, 0.2) !default;
 $dropdown-focus: 1px 3px rgba(color(black), 0.4), 0 1px 15px 3px rgba(color(highlight), 0.75);
 
+/* Base
+  =========================================== */
+
 /**
+ * Dropdown
+ *
  * Dropdown menus are useful tools for navigation, but shouldn't be used for
  * form input purposes (see `c-form-select` for form use).
  *
@@ -26,8 +31,9 @@ $dropdown-focus: 1px 3px rgba(color(black), 0.4), 0 1px 15px 3px rgba(color(high
 }
 
 /**
- * The Dropdown label provides context to the menu and acts as an input to
- * toggle the item list.
+ * Dropdown Toggle
+ *
+ * Provides context to the menu and acts as an input to toggle the item list.
  *
  * 1. Set font-size and line-height
  * 2. Displays the label stacked above its menu items.
@@ -58,7 +64,9 @@ $dropdown-focus: 1px 3px rgba(color(black), 0.4), 0 1px 15px 3px rgba(color(high
   }
 
   /**
-   * The Dropdown label uses an icon to indicate when the menu has been toggled.
+   * Dropdown Toggle - Icon
+   *
+   * The Dropdown toggle uses an icon to indicate when the menu is open.
    * N.B. Temporary use of Base64 until a Sky SVG solution is realised.
    *
    * 3. Allows for positioning from the top and right of the dropdown.
@@ -88,7 +96,9 @@ $dropdown-focus: 1px 3px rgba(color(black), 0.4), 0 1px 15px 3px rgba(color(high
 }
 
 /**
- * The Dropdown list contains menu items, appearing when the label is toggled.
+ * Dropdown List
+ *
+ * Contains menu items, appearing when the label is toggled.
  *
  * 1. Removes default list margins.
  * 2. Sets the list to be stacked above the the label.
@@ -118,7 +128,9 @@ $dropdown-focus: 1px 3px rgba(color(black), 0.4), 0 1px 15px 3px rgba(color(high
   transition: all $dropdown-animation-speed ease; /* [13] */
 
   /**
-   * As the Dropdown label and Dropdown list use similar box-shadows, there will
+   * Dropdown Overlap Fix
+   *
+   * As the Dropdown toggle and list use similar box-shadows, there will
    * inevitably be overlap. To prevent this overlap, the Dropdown list uses a
    * pseudo-element with a matching background-color to cover the shadow.
    *
@@ -137,8 +149,9 @@ $dropdown-focus: 1px 3px rgba(color(black), 0.4), 0 1px 15px 3px rgba(color(high
 }
 
 /**
- * The Dropdown link class provides styling for individual menu items within the
- * Dropdown list.
+ * Dropdown Link
+ *
+ * Provides styling for individual menu items within the Dropdown list.
  *
  * 1. Overides default link color.
  * 2. As we use scaleY on the Dropdown list to toggle the menu, each item is
@@ -168,13 +181,14 @@ $dropdown-focus: 1px 3px rgba(color(black), 0.4), 0 1px 15px 3px rgba(color(high
   }
 }
 
+/* States
+  =========================================== */
+
 /**
  * When a dropdown's state is toggled.
  */
 .c-dropdown.is-open {
   /**
-   * Dropdown list on toggle.
-   *
    * 1. Scales vertical axis to its full height to achieve 'slide' animation.
    * 2. Sets text to its correct height to animate upon.
   */
@@ -192,8 +206,6 @@ $dropdown-focus: 1px 3px rgba(color(black), 0.4), 0 1px 15px 3px rgba(color(high
   }
 
   /**
-   * Dropdown label on toggle.
-   *
    * 1. Removes border-radius on bottom edge to overlap the dropdown list.
    * 2. Rotates icon indicator 180 degrees.
   */
@@ -209,7 +221,7 @@ $dropdown-focus: 1px 3px rgba(color(black), 0.4), 0 1px 15px 3px rgba(color(high
   }
 }
 
-/* Dropdown sizing modifiers
+/* Modifiers
    =========================================== */
 
 /**

--- a/components/_dropdown.scss
+++ b/components/_dropdown.scss
@@ -1,5 +1,5 @@
 /* ==========================================================================
-   COMPONENTS / DROPDOWN
+   COMPONENTS / #DROPDOWN
    ========================================================================== */
 
 // Dropdown settings
@@ -49,6 +49,7 @@ $dropdown-focus: 1px 3px rgba(color(black), 0.4), 0 1px 15px 3px rgba(color(high
   outline: 0;
   cursor: pointer;
   z-index: 1; /* [4] */
+  text-align: left;
   transition: border $dropdown-animation-speed ease, border-radius $dropdown-animation-speed ease, box-shadow $dropdown-animation-speed ease;
 
   &:focus {
@@ -217,6 +218,7 @@ $dropdown-focus: 1px 3px rgba(color(black), 0.4), 0 1px 15px 3px rgba(color(high
 .c-dropdown--full {
   display: block;
   width: 100%;
+
   .c-dropdown__toggle {
     width: 100%;
   }
@@ -226,9 +228,10 @@ $dropdown-focus: 1px 3px rgba(color(black), 0.4), 0 1px 15px 3px rgba(color(high
 * For dropdowns that need to display full-width on small devices only.
 */
 .c-dropdown--full\@small-only {
-  @include mq($until: medium) {
+  @include mq($until: small) {
     display: block;
     width: 100%;
+
     .c-dropdown__toggle {
       width: 100%;
     }


### PR DESCRIPTION
Provide a general summary of your changes in the Title above

## Description
I added a property to allow the button to be full-width when the button's parent have the className `c-dropdown--full` or `c-dropdown--full@small-only`

## Related Issue
Please link to the issue here

## Motivation and Context
This change was required because the className `c-dropdown--full` didn't apply full-width
Now the dropdown is full width when use `c-dropdown--full` and `c-dropdown--full@small-only`

## How Has This Been Tested?
I created a local project to test if the class worked, I tested `c-dropdown--full` and `c-dropdown--full@small-only`

Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.

## Screenshots (if appropriate)

## Types of Changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Browser Support
- [x] Chrome
- [x] Edge
- [x] Firefox
- [x] IE9
- [x] IE10
- [x] IE11
- [x] Opera
- [x] Safari
- [x] Mobile Devices
- [x] Screen-readers (e.g. JAWS, Apple VoiceOver)

## Checklist
- [x] All code includes full inline documentation (as per the [template](https://github.com/sky-uk/toolkit-core/blob/master/_template.scss)).
- [x] All code conforms to the Toolkit [coding style](https://github.com/sky-uk/toolkit/wiki/Coding-Style).
- [x] All code conforms to [WCAG 2.0 level AA Accessibility Guidelines](https://www.w3.org/TR/WCAG20/).
- [ ] New functions and mixins have appropriate tests.
- [ ] All new and existing tests passed.
- [ ] I have added instructions on how to test my changes.
- [ ] Package version updated.
- [ ] CHANGELOG.md updated. (