### PR TITLE
[Linter] Update rules and move to sky-uk/css

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,1 +1,1 @@
-node_modules/sky-toolkit-core/.stylelintrc
+node_modules/sky-css-lint/.stylelintrc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Toolkit UI v1.5.0
 
-## 1. Fixes
+## 1. Dependencies
+- [toolkit-core](https://github.com/sky-uk/toolkit-core) updated to `1.4.0`.
+
+## 2. Fixes
 - [tile] Prevent IE9 adding height attributes for asynchronously rendered images.
 - [tooltip] Fix for mobile appearance. Fix for `c-tooltip--right` on hover.
 

--- a/components/_calendar.scss
+++ b/components/_calendar.scss
@@ -204,6 +204,8 @@ $calendar-navigation-modifiers: (
   -webkit-transition: background $calendar-animation-speed, color $calendar-animation-speed, transform $calendar-animation-speed;
   transition: background $calendar-animation-speed, color $calendar-animation-speed, transform $calendar-animation-speed; /* [3] */
 
+  /* Box-shadow to smooth pixel border is hidden on high resolution displays */
+  /* stylelint-disable indentation, media-feature-name-no-unknown */
   @media
     only screen and (-webkit-min-device-pixel-ratio: 2),
     only screen and (min--moz-device-pixel-ratio: 2),
@@ -211,8 +213,9 @@ $calendar-navigation-modifiers: (
     only screen and (min-device-pixel-ratio: 2),
     only screen and (min-resolution: 192dpi),
     only screen and (min-resolution: 2dppx) {
-    box-shadow: none; /* [4] */
+      box-shadow: none; /* [4] */
   }
+  /* stylelint-enable */
 
   @include hocus() {
     background: color(brand);

--- a/components/_panel.scss
+++ b/components/_panel.scss
@@ -77,6 +77,8 @@ $panel-background-color-dark: color(grey-50) !default;
   right: $global-spacing-unit-small; /* [1] */
   color: color(text);
 
+  /* Toggle icon shouldn't inherit the default link text-decoration */
+  /* stylelint-disable declaration-no-important */
   &::after {
     display: inline-block;
     position: relative;  /* [2] */
@@ -86,6 +88,7 @@ $panel-background-color-dark: color(grey-50) !default;
     margin-left: $global-spacing-unit-tiny;
     text-decoration: none !important;
   }
+  /* stylelint-enable */
 
   .c-panel--dark & {
     color: color(white);

--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
   },
   "homepage": "https://github.com/sky-uk/toolkit-ui#readme",
   "dependencies": {
-    "sky-toolkit-core": "1.3.0"
+    "sky-toolkit-core": "1.4.0"
   }
 }


### PR DESCRIPTION
## Description
Utilises an updated CSS lint ruleset, taken from Sky's CSS Style Guide

**Not to be merged until [sky-uk/css](https://github.com/sky-uk/css) is production ready**

## Related Issue
https://github.com/sky-uk/toolkit-core/issues/159

## Motivation and Context
Improvements to existing lint, shareability in projects that don't consume the Toolkit for company-wide consistency.

## How Has This Been Tested?
TBC


## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Browser Support
N/A

## Checklist
- [x] All code includes full inline documentation (as per the [template](https://github.com/sky-uk/toolkit-core/blob/master/_template.scss)).
- [x] All code conforms to the Toolkit [coding style](https://github.com/sky-uk/toolkit/wiki/Coding-Style).
- [x] All code conforms to [WCAG 2.0 level AA Accessibility Guidelines](https://www.w3.org/TR/WCAG20/).
- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] I have added instructions on how to test my changes.
- [x] Package version updated.
- [x] CHANGELOG.md updated.
