### PR TITLE
Bring in required deps as devDependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Toolkit UI v1.5.1
+
+## 1. Fixes
+- [package] Manage own dependencies. Added `devDependencies`
+
+===
+
 # Toolkit UI v1.5.0
 
 ## 1. Dependencies

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sky-toolkit-ui",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "The UI layer of Sky's CSS Toolkit",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,10 +4,11 @@
   "description": "The UI layer of Sky's CSS Toolkit",
   "main": "index.js",
   "scripts": {
+    "clean": "rm -rf build",
     "test": "./node_modules/mocha/bin/mocha ./test/sass.js",
     "test-circle": "npm run build && npm run test",
     "lint": "stylelint ./**/*.scss --syntax scss",
-    "build": "mkdir build && cat ./test/_build.scss | node_modules/.bin/node-sass --include-path node_modules/ --output-style compressed > build/toolkit.css"
+    "build": "npm run clean && mkdir build && cat ./test/_build.scss | node_modules/.bin/node-sass --include-path node_modules/ --output-style compressed > build/toolkit.css"
   },
   "pre-commit": [
     "lint",
@@ -25,5 +26,14 @@
   "homepage": "https://github.com/sky-uk/toolkit-ui#readme",
   "dependencies": {
     "sky-toolkit-core": "1.4.0"
+  },
+  "devDependencies": {
+    "eyeglass": "^1.1.2",
+    "mocha": "^2.4.5",
+    "node-sass": "^3.4.2",
+    "pre-commit": "^1.1.2",
+    "sass-mq": "^3.2.6",
+    "sass-true": "2.0.3",
+    "sky-css-lint": "1.0.0"
   }
 }


### PR DESCRIPTION
Provide a general summary of your changes in the Title above

## Description
Packages should require in their own dependencies.

## Related Issue
Related to a PR in `toolkit-core` https://github.com/sky-uk/toolkit-core/pull/163

## Motivation and Context
Why is this change required?
Packages should require in their own dependencies.
What problem does it solve?
Reliance on `toolkit-core` to bring in devDependencies as dependencies
What program is it supporting? e.g. Toolkit evolution / Sky Mobile
All, `toolkit-core` registered as an invalid module in a `sky-pages-renderer` app.

## How Has This Been Tested?
Please describe in detail how you tested your changes.
Ran tests and built.

Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.
Should not affect appearance.

## Screenshots (if appropriate)

## Types of Changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Browser Support
N/A

## Checklist
- N/A All code includes full inline documentation (as per the [template](https://github.com/sky-uk/toolkit-core/blob/master/_template.scss)).
- [x] All code conforms to the Toolkit [coding style](https://github.com/sky-uk/toolkit/wiki/Coding-Style).
- N/A All code conforms to [WCAG 2.0 level AA Accessibility Guidelines](https://www.w3.org/TR/WCAG20/).
- N/A New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- N/A (CI does this) I have added instructions on how to test my changes.
- [x] Package version updated.
- [x] CHANGELOG.md updated.
