### PR TITLE
Redirect new toolkit-ui issues to the main Toolkit repo

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,37 +1,3 @@
-Provide a general summary of the issue in the Title above
+:warning: **We no longer accept Issues in this repo**
 
-## Expected Behavior
-If you're describing a bug, tell us what should happen
-
-If you're suggesting a change/improvement, tell us how it should work
-
-## Current Behavior
-If describing a bug, tell us what happens instead of the expected behavior
-
-If suggesting a change/improvement, explain the difference from current behavior
-
-## Attempted Fixes
-What have you tried to resolve this issue?
-What have you done to mitigate this problem within your own application?
-
-## Steps to Reproduce (for bugs)
-Provide a link to a live example, or an unambiguous set of steps to
-reproduce this bug. Include code to reproduce, if relevant
-
-0.
-0.
-0.
-0.
-
-## Context
-How has this issue affected you?
-Why is this change required?
-What problem does it solve?
-What program is it supporting? e.g. Toolkit evolution / Sky Mobile
-
-## Your Environment
-Include as many relevant details about the environment you experienced the bug in
-
-Version used:
-* Environment name and version (e.g. Chrome 39, node.js 5.4):
-* Operating System and version (desktop or mobile):
+Instead, please raise an issue in the main [**Toolkit** repo](https://github.com/sky-uk/toolkit/issues/new), along with a `toolkit-ui` label.


### PR DESCRIPTION
## Description
Update the issue template to redirect developers to the main repo for future issues.

This update shouldn't require a version bump.