### PR TITLE
[Shine] Transition patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Toolkit UI v1.8.1
+
+## 1. Patches
+- [shine] Remove `opacity` animation from `c-shine-rail` and add to `c-shine-context`.
+
+===
+
 # Toolkit UI v1.8.0
 
 ## 1. Fixes

--- a/components/_shine.scss
+++ b/components/_shine.scss
@@ -37,7 +37,6 @@ $shine-size: 45px;
   will-change: transform;
   position: relative;
   height: 100%;
-  opacity: 0;
   overflow: hidden;
 
   /**

--- a/components/_shine.scss
+++ b/components/_shine.scss
@@ -90,16 +90,20 @@ $shine-size: 45px;
  * Applied to the parent node in which the shine is contained, animating shine
  * rails on hover.
  */
-.c-shine-context:hover {
+.c-shine-context {
   /*! autoprefixer: off */
   .c-shine__rail {
-    opacity: 1;
-    -ms-transform: translateX(25%);
-    transform: translateX(25%);
+    opacity: 0;
   }
 
-  .c-shine--rev {
+  &:hover {
     .c-shine__rail {
+      opacity: 1;
+      -ms-transform: translateX(25%);
+      transform: translateX(25%);
+    }
+
+    .c-shine--rev .c-shine__rail {
       -ms-transform: translateX(-25%);
       transform: translateX(-25%);
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sky-toolkit-ui",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "The UI layer of Sky's CSS Toolkit",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Description
Quick **Patches O'Houlihan** for the Shine transition
<img width="847" alt="screen shot 2017-03-10 at 11 37 20" src="https://cloud.githubusercontent.com/assets/7349341/23794030/0fe35da4-0586-11e7-8912-8e1f0062ad46.png">
- Move opacity animation to `c-shine-context`

## Related Issue
https://github.com/sky-uk/toolkit-ui/pull/218

## Motivation and Context
Currently blocking Hero shine animation

## How Has This Been Tested?
Tested in toolkit-react and Sky Pages

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Browser Support
- [x] Chrome
- [x] Edge
- [x] Firefox
- [x] IE9
- [x] IE10
- [x] IE11
- [x] Opera
- [x] Safari
- [x] Mobile Devices
- [x] Screen-readers (e.g. JAWS, Apple VoiceOver)

## Checklist
- [x] All code includes full inline documentation (as per the [template](https://github.com/sky-uk/toolkit-core/blob/master/_template.scss)).
- [x] All code conforms to the Toolkit [coding style](https://github.com/sky-uk/toolkit/wiki/Coding-Style).
- [x] All code conforms to [WCAG 2.0 level AA Accessibility Guidelines](https://www.w3.org/TR/WCAG20/).
- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] I have added instructions on how to test my changes.
- [x] Package version updated.
- [x] CHANGELOG.md updated.

---

cc/ @coderas