### PR TITLE
Added z-index properties to c-tabs__article classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 `sky-toolkit-ui` follows [Semantic Versioning](http://semver.org) to help manage the impact of releasing new library versions.
 
 
+## 1.13.0
+
+### Fixes
+- [tabs] Accessibility improvements and fix for selectable tab content.
+
+### Dependencies
+- [toolkit-core](https://github.com/sky-uk/toolkit-core) updated to `1.11.0`.
+
+
 ## 1.12.0
 
 ### Features

--- a/components/_tabs.scss
+++ b/components/_tabs.scss
@@ -286,6 +286,7 @@ $tabs-container-width: $global-container-width;
   top: 0;
   left: 0;
   right: 0;
+  z-index: -1;
 }
 
 /**
@@ -325,6 +326,7 @@ $tabs-container-width: $global-container-width;
  */
 .c-tabs__article.is-active {
   position: relative;
+  z-index: 0;
 
   .c-tabs__body {
     opacity: 1;

--- a/components/_tabs.scss
+++ b/components/_tabs.scss
@@ -286,7 +286,6 @@ $tabs-container-width: $global-container-width;
   top: 0;
   left: 0;
   right: 0;
-  z-index: -1;
 }
 
 /**
@@ -297,10 +296,9 @@ $tabs-container-width: $global-container-width;
  */
 .c-tabs__body {
   opacity: 0;
-  transition-property: opacity;
-  transition-duration: $tabs-animation-speed*2;
-  transform-style: ease;
-  transition-delay: 0s;
+  visibility: hidden;
+  transition: opacity $tabs-animation-speed ease, visibility 0s;
+  transition-delay: 0s, $tabs-animation-speed;
 }
 
 /* States
@@ -326,10 +324,11 @@ $tabs-container-width: $global-container-width;
  */
 .c-tabs__article.is-active {
   position: relative;
-  z-index: 0;
+  z-index: 1;
 
   .c-tabs__body {
     opacity: 1;
+    visibility: visible;
     transition-delay: $tabs-animation-speed; /* [1] */
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/sky-uk/toolkit-ui#readme",
   "dependencies": {
-    "sky-toolkit-core": "git+ssh://git@github.com/sky-uk/toolkit-core.git#tkt-00205"
+    "sky-toolkit-core": "1.11.0"
   },
   "devDependencies": {
     "eyeglass": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sky-toolkit-ui",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "The UI layer of Sky's CSS Toolkit",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/sky-uk/toolkit-ui#readme",
   "dependencies": {
-    "sky-toolkit-core": "1.10.0"
+    "sky-toolkit-core": "git+ssh://git@github.com/sky-uk/toolkit-core.git#tkt-00205"
   },
   "devDependencies": {
     "eyeglass": "^1.2.1",


### PR DESCRIPTION
## Description
This is to fix a bug where hidden articles are clickable instead of the active article

## Related Issue
Found in sky-uk/sky-pages#4077

## Motivation and Context
Bug fix

## How Has This Been Tested?
Tested in linked PR

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Browser Support
- [ ] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] IE9
- [ ] IE10
- [ ] IE11
- [ ] Opera
- [ ] Safari
- [ ] Mobile Devices
- [ ] Screen-readers (e.g. JAWS, Apple VoiceOver)

## Checklist
- [ ] All code includes full inline documentation (as per the [template](https://github.com/sky-uk/toolkit-core/blob/master/_template.scss)).
- [ ] All code conforms to the Toolkit [coding style](https://github.com/sky-uk/toolkit/wiki/Coding-Style).
- [ ] All code conforms to [WCAG 2.0 level AA Accessibility Guidelines](https://www.w3.org/TR/WCAG20/).
- [ ] New functions and mixins have appropriate tests.
- [ ] All new and existing tests passed.
- [ ] I have added instructions on how to test my changes.
- [ ] Package version updated.
- [ ] CHANGELOG.md updated.
