### PR TITLE
[refs #215] Deprecations for Toolkit 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 `sky-toolkit-ui` follows [Semantic Versioning](http://semver.org) to help manage the impact of releasing new library versions.
 
+
+## 1.16.0
+
+### Dependencies
+
+* [toolkit-core](https://github.com/sky-uk/toolkit-core) updated to `1.13.0`.
+
+### Deprecation Warnings
+
+The following will be removed in Toolkit@2.0.0:
+
+* [typography]
+  * Removal of `.c-text-lead-small`. Use `.c-text-body` instead.
+  * Removal of `.c-text-body-small`. Use `.c-text-body` instead.
+
+If you experience any issues with these required changes, please visit https://git.io/v9b7v for next steps.
+
+
 ## 1.15.0
 
 ### Features
@@ -17,6 +35,7 @@
     <span class="c-switch__label">Example</span>
 </label>
 ```
+
 
 ## 1.14.0
 

--- a/components/_accordion.scss
+++ b/components/_accordion.scss
@@ -49,7 +49,7 @@ $accordion-icon-size: 20px !default;
  * 5. Overwrite browser interaction styles to hide outline and show pointer.
  */
 .c-accordion__label {
-  @include font-size(text-body-small); /* [1] */
+  @include font(text-body-small); /* [1] */
   display: block; /* [2] */
   position: relative; /* [2] */
   font-weight: bold; /* [1] */

--- a/components/_accordion.scss
+++ b/components/_accordion.scss
@@ -49,7 +49,7 @@ $accordion-icon-size: 20px !default;
  * 5. Overwrite browser interaction styles to hide outline and show pointer.
  */
 .c-accordion__label {
-  @include font(text-body-small); /* [1] */
+  @include font(text-body-small, large, disable-warning); /* [1] */
   display: block; /* [2] */
   position: relative; /* [2] */
   font-weight: bold; /* [1] */

--- a/components/_buttons.scss
+++ b/components/_buttons.scss
@@ -3,7 +3,7 @@
    ========================================================================== */
 
 // Button settings
-$btn-font-size: font-size(text-lead-small) !default;
+$btn-font-size: font-size(text-lead-small, large, disable-warning) !default;
 $btn-padding-x: 15px !default;
 $btn-padding-y: 5px !default;
 $btn-border-width: $global-border-width !default;

--- a/components/_buttons.scss
+++ b/components/_buttons.scss
@@ -3,7 +3,7 @@
    ========================================================================== */
 
 // Button settings
-$btn-font-size: text(text-lead-small) !default;
+$btn-font-size: font-size(text-lead-small) !default;
 $btn-padding-x: 15px !default;
 $btn-padding-y: 5px !default;
 $btn-border-width: $global-border-width !default;

--- a/components/_dropdown.scss
+++ b/components/_dropdown.scss
@@ -41,7 +41,7 @@ $dropdown-shadow-active: 0 0 $dropdown-shadow-blur-radius 0 rgba(0, 0, 0, 0.2) !
  *    (essential for the shadow overlap fix)
  */
 .c-dropdown__toggle {
-  @include font-size(text-lead-small); /* [1] */
+  @include font(text-lead-small); /* [1] */
   display: block; /* [2] */
   position: relative;
   padding: $global-spacing-unit-tiny/2 $global-spacing-unit-large $global-spacing-unit-tiny/2 $global-spacing-unit-small; /* [3] */
@@ -161,7 +161,7 @@ $dropdown-shadow-active: 0 0 $dropdown-shadow-blur-radius 0 rgba(0, 0, 0, 0.2) !
  */
 .c-dropdown__link {
   /*! autoprefixer: off */
-  @include font-size(text-lead-small);
+  @include font(text-lead-small);
   display: block;
   width: 100%;
   padding: $global-spacing-unit-tiny/2 $global-spacing-unit-small;

--- a/components/_dropdown.scss
+++ b/components/_dropdown.scss
@@ -41,7 +41,7 @@ $dropdown-shadow-active: 0 0 $dropdown-shadow-blur-radius 0 rgba(0, 0, 0, 0.2) !
  *    (essential for the shadow overlap fix)
  */
 .c-dropdown__toggle {
-  @include font(text-lead-small); /* [1] */
+  @include font(text-lead-small, large, disable-warning); /* [1] */
   display: block; /* [2] */
   position: relative;
   padding: $global-spacing-unit-tiny/2 $global-spacing-unit-large $global-spacing-unit-tiny/2 $global-spacing-unit-small; /* [3] */
@@ -161,7 +161,7 @@ $dropdown-shadow-active: 0 0 $dropdown-shadow-blur-radius 0 rgba(0, 0, 0, 0.2) !
  */
 .c-dropdown__link {
   /*! autoprefixer: off */
-  @include font(text-lead-small);
+  @include font(text-lead-small, large, disable-warning);
   display: block;
   width: 100%;
   padding: $global-spacing-unit-tiny/2 $global-spacing-unit-small;

--- a/components/_forms.scss
+++ b/components/_forms.scss
@@ -340,7 +340,7 @@ $form-animation-speed: $global-animation-speed-fast;
   display: inline-block;
   width: 100%;
   margin-bottom: $global-spacing-unit-tiny;
-  font-size: text($form-font-size);
+  font-size: font-size($form-font-size);
   cursor: pointer;
 }
 

--- a/components/_forms.scss
+++ b/components/_forms.scss
@@ -88,7 +88,7 @@ $form-animation-speed: $global-animation-speed-fast;
  *
  */
 .c-form-label {
-  @include font($form-font-size, large);
+  @include font($form-font-size, large, disable-warning);
   display: inline-block;
   margin-bottom: $global-spacing-unit-tiny;
 }
@@ -104,7 +104,7 @@ $form-animation-speed: $global-animation-speed-fast;
  * 2. Padding added via line-height/height to re-center text for all browsers (38px to account for border).
  */
 .c-form-input {
-  @include font($form-font-size, large);
+  @include font($form-font-size, large, disable-warning);
   display: inline-block;
   padding: 0 $global-spacing-unit-tiny; /* [1] */
   margin-bottom: $global-spacing-unit-tiny;
@@ -149,7 +149,7 @@ $form-animation-speed: $global-animation-speed-fast;
  * iOS Safari and Android. Other browsers will fallback to a text field.
  */
 .c-form-date {
-  @include font($form-font-size, large);
+  @include font($form-font-size, large, disable-warning);
   display: inline-block;
   padding: $global-spacing-unit-tiny/2 $global-spacing-unit-tiny;
   margin-bottom: $global-spacing-unit-tiny;
@@ -226,7 +226,7 @@ $form-animation-speed: $global-animation-speed-fast;
  */
 .c-form-combo__btn,
 .c-form-combo__input {
-  @include font($form-font-size, large);
+  @include font($form-font-size, large, disable-warning);
   padding-top: $global-spacing-unit-tiny/2;
   padding-bottom: $global-spacing-unit-tiny/2;
 }
@@ -235,7 +235,7 @@ $form-animation-speed: $global-animation-speed-fast;
   =========================================== */
 
 .c-form-select {
-  @include font($form-font-size, large);
+  @include font($form-font-size, large, disable-warning);
   line-height: 1.2;
   display: inline-block;
   margin-bottom: $global-spacing-unit-tiny;
@@ -340,7 +340,7 @@ $form-animation-speed: $global-animation-speed-fast;
   display: inline-block;
   width: 100%;
   margin-bottom: $global-spacing-unit-tiny;
-  font-size: font-size($form-font-size);
+  font-size: font-size($form-font-size, large, disable-warning);
   cursor: pointer;
 }
 

--- a/components/_forms.scss
+++ b/components/_forms.scss
@@ -88,7 +88,7 @@ $form-animation-speed: $global-animation-speed-fast;
  *
  */
 .c-form-label {
-  @include font-size($form-font-size, large);
+  @include font($form-font-size, large);
   display: inline-block;
   margin-bottom: $global-spacing-unit-tiny;
 }
@@ -104,7 +104,7 @@ $form-animation-speed: $global-animation-speed-fast;
  * 2. Padding added via line-height/height to re-center text for all browsers (38px to account for border).
  */
 .c-form-input {
-  @include font-size($form-font-size, large);
+  @include font($form-font-size, large);
   display: inline-block;
   padding: 0 $global-spacing-unit-tiny; /* [1] */
   margin-bottom: $global-spacing-unit-tiny;
@@ -149,7 +149,7 @@ $form-animation-speed: $global-animation-speed-fast;
  * iOS Safari and Android. Other browsers will fallback to a text field.
  */
 .c-form-date {
-  @include font-size($form-font-size, large);
+  @include font($form-font-size, large);
   display: inline-block;
   padding: $global-spacing-unit-tiny/2 $global-spacing-unit-tiny;
   margin-bottom: $global-spacing-unit-tiny;
@@ -226,7 +226,7 @@ $form-animation-speed: $global-animation-speed-fast;
  */
 .c-form-combo__btn,
 .c-form-combo__input {
-  @include font-size($form-font-size, large);
+  @include font($form-font-size, large);
   padding-top: $global-spacing-unit-tiny/2;
   padding-bottom: $global-spacing-unit-tiny/2;
 }
@@ -235,7 +235,7 @@ $form-animation-speed: $global-animation-speed-fast;
   =========================================== */
 
 .c-form-select {
-  @include font-size($form-font-size, large);
+  @include font($form-font-size, large);
   line-height: 1.2;
   display: inline-block;
   margin-bottom: $global-spacing-unit-tiny;

--- a/components/_panel.scss
+++ b/components/_panel.scss
@@ -70,7 +70,7 @@ $panel-background-color-dark: color(grey-50) !default;
  */
 
 .c-panel__toggle {
-  @include font-size(text-lead-small);
+  @include font(text-lead-small);
   line-height: 1;
   position: absolute; /* [1] */
   top: $global-spacing-unit-small; /* [1] */

--- a/components/_panel.scss
+++ b/components/_panel.scss
@@ -70,7 +70,7 @@ $panel-background-color-dark: color(grey-50) !default;
  */
 
 .c-panel__toggle {
-  @include font(text-lead-small);
+  @include font(text-lead-small, large, disable-warning);
   line-height: 1;
   position: absolute; /* [1] */
   top: $global-spacing-unit-small; /* [1] */

--- a/components/_tile-fluid.scss
+++ b/components/_tile-fluid.scss
@@ -88,9 +88,9 @@ $tile-fluid-max-width: $global-container-width !default;
    * 2. Set margin bottom in em relative to the elements font-size (36px)
    */
   .c-tile__title {
-    font-size: convert-to-em(text(heading-charlie)); /* [1] */
+    font-size: convert-to-em(font-size(heading-charlie)); /* [1] */
     line-height: 1.25em;
-    margin-bottom: convert-to-em($global-spacing-unit-tiny, text(heading-charlie));  /* [2] */
+    margin-bottom: convert-to-em($global-spacing-unit-tiny, font-size(heading-charlie));  /* [2] */
   }
 }
 

--- a/components/_tile.scss
+++ b/components/_tile.scss
@@ -278,7 +278,7 @@ $included-tile-themes: "sky-1", "sky-account", "sky-atlantic", "sky-arts", "sky-
  */
 .c-tile__title {
   position: relative;
-  font-size: text(heading-delta);
+  font-size: font-size(heading-delta);
   line-height: 1.3;
 
   @include mq($from: medium) {
@@ -286,11 +286,11 @@ $included-tile-themes: "sky-1", "sky-account", "sky-atlantic", "sky-arts", "sky-
   }
 
   @include mq($from: large) {
-    font-size: text(heading-charlie);
+    font-size: font-size(heading-charlie);
   }
 
   .c-tile--full & {
-    font-size: text(heading-delta);
+    font-size: font-size(heading-delta);
 
     @include mq($from: medium, $until: large) {
       font-size: 2.8vw;
@@ -303,11 +303,11 @@ $included-tile-themes: "sky-1", "sky-account", "sky-atlantic", "sky-arts", "sky-
  */
 .c-tile__small-title {
   position: relative;
-  font-size: text(heading-delta);
+  font-size: font-size(heading-delta);
   line-height: 1.3;
 
   @include mq($from: medium) {
-    font-size: text(text-lead);
+    font-size: font-size(text-lead);
   }
 }
 

--- a/components/_tooltip.scss
+++ b/components/_tooltip.scss
@@ -92,7 +92,7 @@ $tooltip-z-base: 50;
    *    margins
    */
   .c-tooltip__content {
-    @include font-size(text-body-small);
+    @include font(text-body-small);
     display: block;
     position: absolute;
     z-index: $tooltip-z-base+2; /* [1] */

--- a/components/_tooltip.scss
+++ b/components/_tooltip.scss
@@ -92,7 +92,7 @@ $tooltip-z-base: 50;
    *    margins
    */
   .c-tooltip__content {
-    @include font(text-body-small);
+    @include font(text-body-small, large, disable-warning);
     display: block;
     position: absolute;
     z-index: $tooltip-z-base+2; /* [1] */

--- a/components/_typography.scss
+++ b/components/_typography.scss
@@ -14,41 +14,41 @@
   =========================================== */
 
 .c-heading-alpha {
-  @include font-size(heading-alpha, small);
+  @include font(heading-alpha, small);
   line-height: 1.3;
 
   @include mq($from: medium) {
-    @include font-size(heading-alpha, large);
+    @include font(heading-alpha, large);
     line-height: 1.2;
   }
 }
 
 .c-heading-bravo {
-  @include font-size(heading-bravo, small);
+  @include font(heading-bravo, small);
   line-height: 1.3;
 
   @include mq($from: medium) {
-    @include font-size(heading-bravo, large);
+    @include font(heading-bravo, large);
     line-height: 1.25;
   }
 }
 
 .c-heading-charlie {
-  @include font-size(heading-charlie, small);
+  @include font(heading-charlie, small);
   line-height: 1.3;
 
   @include mq($from: medium) {
-    @include font-size(heading-charlie, large);
+    @include font(heading-charlie, large);
     line-height: 1.25;
   }
 }
 
 .c-heading-delta {
-  @include font-size(heading-delta, small);
+  @include font(heading-delta, small);
   line-height: 1.4;
 
   @include mq($from: medium) {
-    @include font-size(heading-delta, large);
+    @include font(heading-delta, large);
     line-height: 1.3;
   }
 }
@@ -57,51 +57,51 @@
   =========================================== */
 
 .c-text-lead {
-  @include font-size(text-lead, small);
+  @include font(text-lead, small);
   line-height: 1.4;
 
   @include mq($from: medium) {
-    @include font-size(text-lead, large);
+    @include font(text-lead, large);
     line-height: 1.4;
   }
 }
 
 .c-text-body {
-  @include font-size(text-body, small);
+  @include font(text-body, small);
   line-height: 1.4;
 
   @include mq($from: medium) {
-    @include font-size(text-body, large);
+    @include font(text-body, large);
     line-height: 1.4;
   }
 }
 
 .c-text-lead-small {
-  @include font-size(text-lead-small, small);
+  @include font(text-lead-small, small);
   line-height: 1.5;
 
   @include mq($from: medium) {
-    @include font-size(text-lead-small, large);
+    @include font(text-lead-small, large);
     line-height: 1.4;
   }
 }
 
 .c-text-body-small {
-  @include font-size(text-body-small, small);
+  @include font(text-body-small, small);
   line-height: 1.5;
 
   @include mq($from: medium) {
-    @include font-size(text-body-small, large);
+    @include font(text-body-small, large);
     line-height: 1.5;
   }
 }
 
 .c-text-smallprint {
-  @include font-size(text-smallprint, small);
+  @include font(text-smallprint, small);
   line-height: 1.4;
 
   @include mq($from: medium) {
-    @include font-size(text-smallprint, large);
+    @include font(text-smallprint, large);
     line-height: 1.4;
   }
 }

--- a/components/_typography.scss
+++ b/components/_typography.scss
@@ -77,20 +77,22 @@
 }
 
 .c-text-lead-small {
-  @include font(text-lead-small, small);
+  @include font(text-lead-small, small, disable-warning);
   line-height: 1.5;
 
   @include mq($from: medium) {
+    // Leave one warning to alert all consumers of upcoming changes
     @include font(text-lead-small, large);
     line-height: 1.4;
   }
 }
 
 .c-text-body-small {
-  @include font(text-body-small, small);
+  @include font(text-body-small, small, disable-warning);
   line-height: 1.5;
 
   @include mq($from: medium) {
+    // Leave one warning to alert all consumers of upcoming changes
     @include font(text-body-small, large);
     line-height: 1.5;
   }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/sky-uk/toolkit-ui#readme",
   "dependencies": {
-    "sky-toolkit-core": "git+ssh://git@github.com:sky-uk/toolkit-core.git#deprecation-warnings"
+    "sky-toolkit-core": "1.13.0"
   },
   "devDependencies": {
     "eyeglass": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/sky-uk/toolkit-ui#readme",
   "dependencies": {
-    "sky-toolkit-core": "1.12.0"
+    "sky-toolkit-core": "git+ssh://git@github.com:sky-uk/toolkit-core.git#deprecation-warnings"
   },
   "devDependencies": {
     "eyeglass": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sky-toolkit-ui",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "The UI layer of Sky's CSS Toolkit",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## How to test
- Clone
- Run `npm i`
- Run `npm run build` to see warnings

## Description
- Implement `disable-warning` parameter for components to be upgraded
- Leave one warning for both `c-text-body-small` and `c-text-lead-small`.

## Related Issue
https://github.com/sky-uk/toolkit/issues/215

## Motivation and Context
Toolkit 2.0 preparation

## How Has This Been Tested?
All tests pass, no change in outputted CSS

## Sample Warnings
```
➜  toolkit-ui git:(deprecation-warnings) ✗ npm run build

> sky-toolkit-ui@1.15.0 build /Users/jbe42/www/toolkit-ui
> npm run clean && mkdir -p ./build && cat ./test/_build.scss | node_modules/.bin/node-sass --include-path node_modules/ --output-style compressed > build/toolkit.css


> sky-toolkit-ui@1.15.0 clean /Users/jbe42/www/toolkit-ui
> rm -rf build

WARNING: Deprecation [typography]: `text-lead-small`
        Support for `text-lead-small` (and `.c-text-lead-small`) will be removed in Toolkit@2.0.0.
        Use `text-body` (or `.c-text-body`) instead.
        If you experience any issues with this required change, please visit https://git.io/v9b7v for next steps.
Backtrace:
	node_modules/sky-toolkit-core/tools/_functions.scss:16, in function `font-size`
	node_modules/sky-toolkit-core/tools/_typography.scss:25, in mixin `font`
	components/_typography.scss:85, in mixin `@content`
	node_modules/sass-mq/_mq.scss:226, in mixin `mq`
	components/_typography.scss:83

WARNING: Deprecation [typography]: `text-body-small`
        Support for `text-body-small` (and `.c-text-body-small`) will be removed in Toolkit@2.0.0.
        Use `text-body` (or `.c-text-body`) instead.
        If you experience any issues with this required change, please visit https://git.io/v9b7v for next steps.
Backtrace:
	node_modules/sky-toolkit-core/tools/_functions.scss:16, in function `font-size`
	node_modules/sky-toolkit-core/tools/_typography.scss:25, in mixin `font`
	components/_typography.scss:96, in mixin `@content`
	node_modules/sass-mq/_mq.scss:226, in mixin `mq`
	components/_typography.scss:94
```

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Browser Support
- [ ] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] IE9
- [ ] IE10
- [ ] IE11
- [ ] Opera
- [ ] Safari
- [ ] Mobile Devices
- [ ] Screen-readers (e.g. JAWS, Apple VoiceOver)

## Checklist
- [x] All code includes full inline documentation (as per the [template](https://github.com/sky-uk/toolkit-core/blob/master/_template.scss)).
- [x] All code conforms to the Toolkit [coding style](https://github.com/sky-uk/toolkit/wiki/Coding-Style).
- [x] All code conforms to [WCAG 2.0 level AA Accessibility Guidelines](https://www.w3.org/TR/WCAG20/).
- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] I have added instructions on how to test my changes.
- [ ] Package version updated.
- [x] CHANGELOG.md updated.
