### PR TITLE
Deprecate Gradient Mixins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 `sky-toolkit-ui` follows [Semantic Versioning](http://semver.org) to help manage the impact of releasing new library versions.
 
+
+## 1.20.0
+
+### Dependencies
+
+* [toolkit-core](https://github.com/sky-uk/toolkit-core) updated to `1.16.0`.
+
+
 ## 1.19.0
 
 ### Features

--- a/components/_tile.scss
+++ b/components/_tile.scss
@@ -385,11 +385,11 @@ $included-tile-themes: "sky-1", "sky-account", "sky-atlantic", "sky-arts", "sky-
 .c-tile__body {
   /*! autoprefixer: off */
   &::before {
-    @include background-gradient($tile-gradient-default, "radial");
+    @include gradient-background($tile-gradient-default, "radial");
   }
 
   .c-tile__link &::after {
-    @include background-gradient($tile-gradient-default-hover, "radial");
+    @include gradient-background($tile-gradient-default-hover, "radial");
   }
 }
 
@@ -397,11 +397,11 @@ $included-tile-themes: "sky-1", "sky-account", "sky-atlantic", "sky-arts", "sky-
 .c-tile__caption {
   /*! autoprefixer: off */
   &::before {
-    @include background-gradient($tile-gradient-default);
+    @include gradient-background($tile-gradient-default);
   }
 
   .c-tile__link &::after {
-    @include background-gradient($tile-gradient-default-hover);
+    @include gradient-background($tile-gradient-default-hover);
   }
 }
 
@@ -413,7 +413,7 @@ $included-tile-themes: "sky-1", "sky-account", "sky-atlantic", "sky-arts", "sky-
   }
 
   &::after {
-    @include background-gradient(mid, vertical-invert, 0% 50%);
+    @include gradient-background(mid, vertical-invert, 0% 50%);
   }
 }
 
@@ -454,7 +454,7 @@ $included-tile-themes: "sky-1", "sky-account", "sky-atlantic", "sky-arts", "sky-
 
         // Set up style overides
         .c-tile__link .c-tile__body::after {
-          @include background-gradient($brand);
+          @include gradient-background($brand);
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sky-toolkit-ui",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "The UI layer of Sky's CSS Toolkit",
   "main": "index.js",
   "scripts": {
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/sky-uk/toolkit-ui#readme",
   "dependencies": {
-    "sky-toolkit-core": "1.15.0"
+    "sky-toolkit-core": "1.16.0"
   },
   "devDependencies": {
     "eyeglass": "^1.2.1",


### PR DESCRIPTION
**Please note, tests will fail until https://github.com/sky-uk/toolkit-core/pull/190 is merged**

---

## Description
- Rename our mixins to prepare for 2.0 deprecation

## Related Issue
https://github.com/sky-uk/toolkit/issues/223

## Motivation and Context
Further 2.0 development

## How Has This Been Tested?
All tests pass

## Types of Changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] All code includes full inline documentation (as per the [template](https://github.com/sky-uk/toolkit-core/blob/master/_template.scss)).
- [x] All code conforms to the Toolkit [coding style](https://github.com/sky-uk/toolkit/wiki/Coding-Style).
- [x] All code conforms to [WCAG 2.0 level AA Accessibility Guidelines](https://www.w3.org/TR/WCAG20/).
- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] I have added instructions on how to test my changes.
- [ ] Package version updated.
- [ ] CHANGELOG.md updated.
